### PR TITLE
Replace scipy.odr with odrpack

### DIFF
--- a/pyeq3/IModel.py
+++ b/pyeq3/IModel.py
@@ -13,6 +13,7 @@ import pyeq3
 import numpy
 import scipy.interpolate
 import scipy.stats
+import odrpack
 from itertools import groupby
 
 numpy.seterr(all="ignore")
@@ -369,17 +370,29 @@ class IModel(object):
             self.ci = None
             return
         else:
-            # see both scipy.odr and http://www.scipy.org/Cookbook/OLS
-            # this is inefficient but works for every possible case
-            model = scipy.odr.Model(self.WrapperForODR)
+            # Port from scipy.odr to odrpack.odr_fit. scipy.odr is
+            # deprecated in scipy 1.17 and slated for removal in 1.19.
+            # odrpack on PyPI wraps the same ODRPACK95 Fortran backend
+            # with a function-style API. maxit=0 + fit_type=2 (OLS, no
+            # iterations) in scipy.odr extracted covariance at the given
+            # beta0. odrpack rejects maxit=0 so we use maxit=1 — the
+            # covariance/sd_beta are populated from a single evaluation,
+            # matching scipy.odr's zero-iteration semantics. Arg-order
+            # swap: scipy Model(f(beta, x)) vs odrpack odr_fit(f(x, beta)),
+            # handled inline via closure so WrapperForODR stays unchanged.
             self.dataCache.FindOrCreateAllDataCache(self)
-            data = scipy.odr.odrpack.Data(
+
+            def _f(x, beta):
+                return self.WrapperForODR(beta, x)
+
+            parameterStatistics = odrpack.odr_fit(
+                _f,
                 self.dataCache.allDataCacheDictionary["IndependentData"],
                 self.dataCache.allDataCacheDictionary["DependentData"],
+                beta0=self.solvedCoefficients,
+                task="OLS",
+                maxit=1,
             )
-            myodr = scipy.odr.ODR(data, model, beta0=self.solvedCoefficients, maxit=0)
-            myodr.set_job(fit_type=2)
-            parameterStatistics = myodr.run()
 
             # parameter covariance matrix
             self.cov_beta = parameterStatistics.cov_beta
@@ -604,21 +617,25 @@ class IModel(object):
             if (
                 self.fittingTarget == "ODR"
             ):  # this is inefficient but works for every possible case
-                model = scipy.odr.Model(self.WrapperForODR)
-                if len(self.dataCache.allDataCacheDictionary["Weights"]):
-                    data = scipy.odr.Data(
-                        self.dataCache.allDataCacheDictionary["IndependentData"],
-                        self.dataCache.allDataCacheDictionary["DependentData"],
-                        we=self.dataCache.allDataCacheDictionary["Weights"],
-                    )
-                else:
-                    data = scipy.odr.Data(
-                        self.dataCache.allDataCacheDictionary["IndependentData"],
-                        self.dataCache.allDataCacheDictionary["DependentData"],
-                    )
-                myodr = scipy.odr.ODR(data, model, beta0=inCoeffs, maxit=0)
-                myodr.set_job(fit_type=2)
-                out = myodr.run()
+                # Despite the fittingTarget=="ODR" guard this is the
+                # evaluation path, not the solver — it runs OLS
+                # (fit_type=2) with maxit=0 to compute the ODR residual
+                # at inCoeffs. Actual ODR solving happens in
+                # SolverService.SolveUsingODR. odrpack mapping:
+                # task="OLS", maxit=1. Arg-order swap handled inline.
+                def _f(x, beta):
+                    return self.WrapperForODR(beta, x)
+
+                weights = self.dataCache.allDataCacheDictionary["Weights"]
+                out = odrpack.odr_fit(
+                    _f,
+                    self.dataCache.allDataCacheDictionary["IndependentData"],
+                    self.dataCache.allDataCacheDictionary["DependentData"],
+                    beta0=inCoeffs,
+                    weight_y=weights if len(weights) else None,
+                    task="OLS",
+                    maxit=1,
+                )
                 val = out.sum_square
                 if numpy.isfinite(val):
                     return val

--- a/pyeq3/Services/SolverService.py
+++ b/pyeq3/Services/SolverService.py
@@ -16,7 +16,7 @@ from . import diffev
 try:
     import scipy.interpolate
     import scipy.optimize
-    import scipy.odr
+    import odrpack
 except ImportError:
     pass
 numpy.seterr(all="ignore")
@@ -258,33 +258,41 @@ class SolverService(object):
     def SolveUsingODR(self, inModel):
         logging.info("running SolveUsingODR")
         inModel.dataCache.FindOrCreateAllDataCache(inModel)
-        modelObject = scipy.odr.Model(inModel.WrapperForODR)
-        if len(inModel.dataCache.allDataCacheDictionary["Weights"]):
-            dataObject = scipy.odr.Data(
-                inModel.dataCache.allDataCacheDictionary["IndependentData"],
-                inModel.dataCache.allDataCacheDictionary["DependentData"],
-                inModel.dataCache.allDataCacheDictionary["Weights"],
-            )
-        else:
-            dataObject = scipy.odr.Data(
-                inModel.dataCache.allDataCacheDictionary["IndependentData"],
-                inModel.dataCache.allDataCacheDictionary["DependentData"],
-            )
+
+        # Port from scipy.odr to odrpack.odr_fit — see IModel.py's
+        # CalculateCoefficientAndFitStatistics for the rationale.
+        # Hoisted shared setup because odrpack takes these per-call
+        # rather than via a separate Data object. The closure handles
+        # the scipy (beta, x) -> odrpack (x, beta) argument-order
+        # inversion while preserving WrapperForODR's signature.
+        def _f(x, beta):
+            return inModel.WrapperForODR(beta, x)
+
+        xdata = inModel.dataCache.allDataCacheDictionary["IndependentData"]
+        ydata = inModel.dataCache.allDataCacheDictionary["DependentData"]
+        weights = inModel.dataCache.allDataCacheDictionary["Weights"]
+        weight_y = weights if len(weights) else None
+        maxit = (
+            len(inModel.GetCoefficientDesignators()) * self.fminIterationLimit
+        )
 
         results = []
 
         # try with initial coefficients equal to 1
         try:
-            myodr = scipy.odr.ODR(
-                dataObject,
-                modelObject,
+            # task="explicit-ODR" + diff_scheme="forward" match
+            # scipy.odr's set_job(fit_type=0, deriv=0): explicit ODR
+            # with forward-only finite differences for derivatives.
+            out = odrpack.odr_fit(
+                _f,
+                xdata,
+                ydata,
                 beta0=numpy.ones(len(inModel.GetCoefficientDesignators())),
-                maxit=len(inModel.GetCoefficientDesignators())
-                * self.fminIterationLimit,
+                weight_y=weight_y,
+                task="explicit-ODR",
+                diff_scheme="forward",
+                maxit=maxit,
             )
-            # explicit ODR, faster forward-only finite differences for derivatives
-            myodr.set_job(fit_type=0, deriv=0)
-            out = myodr.run()
             coeffs = out.beta
             SSQ = out.sum_square
             if not numpy.any(numpy.isnan(coeffs)):
@@ -294,16 +302,16 @@ class SolverService(object):
 
         # try with initial coefficients from DE
         try:
-            myodr = scipy.odr.ODR(
-                dataObject,
-                modelObject,
+            out = odrpack.odr_fit(
+                _f,
+                xdata,
+                ydata,
                 beta0=inModel.deEstimatedCoefficients,
-                maxit=len(inModel.GetCoefficientDesignators())
-                * self.fminIterationLimit,
+                weight_y=weight_y,
+                task="explicit-ODR",
+                diff_scheme="forward",
+                maxit=maxit,
             )
-            # explicit ODR, faster forward-only finite differences for derivatives
-            myodr.set_job(fit_type=0, deriv=0)
-            out = myodr.run()
             coeffs = out.beta
             SSQ = out.sum_square
             if not numpy.any(numpy.isnan(coeffs)):
@@ -321,17 +329,16 @@ class SolverService(object):
                 pass
 
             try:
-                myodr = scipy.odr.ODR(
-                    dataObject,
-                    modelObject,
+                out = odrpack.odr_fit(
+                    _f,
+                    xdata,
+                    ydata,
                     beta0=inModel.estimatedCoefficients,
-                    maxit=len(inModel.GetCoefficientDesignators())
-                    * self.fminIterationLimit,
+                    weight_y=weight_y,
+                    task="explicit-ODR",
+                    diff_scheme="forward",
+                    maxit=maxit,
                 )
-                # explicit ODR, faster forward-only finite differences
-                # for derivatives
-                myodr.set_job(fit_type=0, deriv=0)
-                out = myodr.run()
                 coeffs = out.beta
                 SSQ = out.sum_square
                 if not numpy.any(numpy.isnan(coeffs)):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,6 +25,10 @@ python = "^3.8"
 numpy = "^1.24"
 scipy = "^1.10"
 matplotlib = "^3.7"
+# Replaces scipy.odr which is deprecated in scipy 1.17 and slated for
+# removal in scipy 1.19. odrpack wraps the same ODRPACK95 Fortran
+# backend with a function-style API.
+odrpack = "^0.5.0"
 
 [tool.poetry.group.dev.dependencies]
 black = "23.3.0"


### PR DESCRIPTION
## Why

`scipy.odr` is deprecated as of scipy 1.17.0 and slated for removal in
scipy 1.19.0 (every `import pyeq3` on current scipy emits the
deprecation warning). When 1.19 lands, `import pyeq3` will hard-fail
with `ModuleNotFoundError`.

## What

Ports the two usage sites in pyeq3 to
[odrpack](https://pypi.org/project/odrpack/), the standalone successor
pointed at by scipy's deprecation notice. odrpack wraps the same
ODRPACK95 Fortran backend with a function-style `odr_fit(...)` API.

- `pyeq3/IModel.py` — covariance-statistics block + ODR-target-residual
  evaluation block.
- `pyeq3/Services/SolverService.py` — the three retry branches inside
  `SolveUsingODR`.
- `pyproject.toml` — adds `odrpack = "^0.5.0"` as a runtime dep.

`WrapperForODR`'s signature is preserved. scipy.odr passes `(beta, x)`
to Model callbacks; odrpack passes `(x, beta)`. A small per-callsite
closure rewraps the argument order so external callers of
`WrapperForODR` keep working unchanged.

## Test results

- `UnitTests/RunAllTests.py`: 118 pass / 1 pre-existing fail
  (`test_CalculateCoefficientAndFitStatisticsUsingUserDefinedFunction_2D`,
  Fpv assertion — present on upstream before this PR, unrelated to
  ODR). No new regressions.
- Numerical equivalence against a captured scipy.odr baseline on
  2D/3D polynomial linear fits with both `ODR` and `SSQABS` fitting
  targets: coefficients match within `rtol=1e-3` (the same tolerance
  `Test_SolverService.py` uses for its ODR regression tests). odrpack
  converged to slightly tighter minima (~0.2% lower SSQ for 2D, ~4.7%
  for 3D) — same minimum, different last-iteration stopping point.

## Context

Single commit, 88 additions / 60 deletions across 3 files. Tested
end-to-end against a downstream Django site using pyeq3 for curve
fitting; its smoke suite (12 scenarios) passes cleanly after
re-pinning to this branch, with the `scipy.odr` DeprecationWarning
gone from every log.