### PR TITLE
Make pyeq3 installable on numpy 2.x and declare the pypandoc dependency

### DIFF
--- a/pyeq3/Utilities/Multifit.py
+++ b/pyeq3/Utilities/Multifit.py
@@ -625,7 +625,7 @@ def FitDataToAllModelsAndOutput(
             )
 
             text = f"{pypandoc.convert_text(equation.GetDisplayHTML(), 'tex', format='html')}"
-            text = text.replace("*", "$\cdot$")
+            text = text.replace("*", r"$\cdot$")
             axes.annotate(
                 f"{text}{equation.GetCoefficientDesignators()}\n{equation.solvedCoefficients}",
                 xy=(1.0, -0.2),

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,13 +22,19 @@ classifiers = [
 
 [tool.poetry.dependencies]
 python = "^3.8"
-numpy = "^1.24"
+# Explicit range rather than caret: "^1.24" caps at <2.0, but the odrpack-based
+# fitting path runs fine on numpy 2.x. Allow both 1.x and 2.x; cap at the next
+# major.
+numpy = ">=1.24,<3"
 scipy = "^1.10"
 matplotlib = "^3.7"
 # Replaces scipy.odr which is deprecated in scipy 1.17 and slated for
 # removal in scipy 1.19. odrpack wraps the same ODRPACK95 Fortran
 # backend with a function-style API.
 odrpack = "^0.5.0"
+# Used by pyeq3.Utilities.Multifit, which pyeq3/Utilities/__init__.py imports
+# eagerly — so `import pyeq3` fails on a clean install without pypandoc.
+pypandoc = "^1.10"
 
 [tool.poetry.group.dev.dependencies]
 black = "23.3.0"


### PR DESCRIPTION
Two packaging fixes that let `pyeq3` install and import cleanly in current environments, plus one warning cleanup. Builds on #8 (the scipy.odr → odrpack port).

### 1. Allow numpy 2.x
`numpy = "^1.24"` caps at `<2.0`. The odrpack fitting path from #8 runs fine on numpy 2.x, but the caret ceiling excludes it — so any project requiring numpy ≥2.0 (increasingly the default) cannot resolve `pyeq3`. Widened to `>=1.24,<3` (1.x still supported, next major guarded).

### 2. Declare the pypandoc dependency
`pyeq3/Utilities/__init__.py` imports `Multifit` eagerly, and `Multifit` does `import pypandoc` at module load — so `import pyeq3` raises `ModuleNotFoundError: No module named 'pypandoc'` on a clean install, since `pypandoc` isn't declared. Added it as a runtime dependency.

### 3. Silence a SyntaxWarning
`"$\cdot$"` in `Multifit.py` has an invalid `\c` escape, which raises a `SyntaxWarning` on Python 3.12+ (slated to become a `SyntaxError`). Switched to a raw string — value-identical.

### Validation
- `pyproject.toml` parses; `numpy = ">=1.24,<3"`, `pypandoc = "^1.10"`.
- `Multifit.py` compiles under `python -W error::SyntaxWarning` with no invalid-escape warning.
- These exact changes have been running downstream in [zunzun-ng](https://github.com/kiloscheffer/zunzun-ng) on numpy 2.4.x (full test suite + end-to-end fit smoke green).

Opened as a **draft** — happy to adjust the numpy ceiling or the pypandoc constraint to match your preferences before marking ready.