### PR TITLE
Use scipy survival functions for Fpv and pstat_beta

### DIFF
--- a/pyeq3/IModel.py
+++ b/pyeq3/IModel.py
@@ -332,8 +332,12 @@ class IModel(object):
             self.Fstat = None
 
         try:
-            # F-statistic p-value
-            self.Fpv = 1.0 - scipy.stats.f.cdf(self.Fstat, self.df_r, self.df_e)
+            # F-statistic p-value. Use the survival function (sf = 1 - cdf)
+            # directly: for the tiny upper-tail probabilities seen here,
+            # 1.0 - cdf loses almost all precision to cancellation (and the
+            # result shifted between scipy versions), whereas sf is computed
+            # in the tail and is stable.
+            self.Fpv = scipy.stats.f.sf(self.Fstat, self.df_r, self.df_e)
         except Exception:
             self.Fpv = None
 
@@ -422,10 +426,12 @@ class IModel(object):
                 self.tstat_beta = None
 
             try:
-                # coef. p-values
-                self.pstat_beta = (
-                    1.0 - scipy.stats.t.cdf(numpy.abs(self.tstat_beta), self.df_e)
-                ) * 2.0
+                # coef. p-values (two-tailed). Use the survival function
+                # for the same reason as Fpv above: 2 * sf(|t|) avoids the
+                # 1 - cdf cancellation in the small-probability tail.
+                self.pstat_beta = 2.0 * scipy.stats.t.sf(
+                    numpy.abs(self.tstat_beta), self.df_e
+                )
             except Exception:
                 self.pstat_beta = None
 

--- a/pyeq3/UnitTests/Test_CalculateCoefficientAndFitStatistics.py
+++ b/pyeq3/UnitTests/Test_CalculateCoefficientAndFitStatistics.py
@@ -21,7 +21,7 @@ class TestCalculateCoefficientAndFitStatistics(unittest.TestCase):
         model_rmse_ShouldBe = 00.142649386595
         model_r2adj_ShouldBe = 0.99598819167
         model_Fstat_ShouldBe = 2483.64151657
-        model_Fpv_ShouldBe = 2.64577248998e-12
+        model_Fpv_ShouldBe = 2.6457213754443016e-12
         model_ll_ShouldBe = 5.81269665017
         model_aic_ShouldBe = -0.693217572758
         model_bic_ShouldBe = -0.620872977703
@@ -30,7 +30,9 @@ class TestCalculateCoefficientAndFitStatistics(unittest.TestCase):
         )
         model_sd_beta_ShouldBe = numpy.array([0.0482103, 0.00093816])
         model_tstat_beta_ShouldBe = numpy.array([-36.52226166, 49.83614545])
-        model_pstat_beta_ShouldBe = numpy.array([4.28455049e-11, 2.64588351e-12])
+        model_pstat_beta_ShouldBe = numpy.array(
+            [4.2845356344100259e-11, 2.6457203351386194e-12]
+        )
         model_ci_ShouldBe = numpy.array(
             [
                 [-8.5158339321793157, -7.5224373409719512],
@@ -115,7 +117,7 @@ class TestCalculateCoefficientAndFitStatistics(unittest.TestCase):
         model_rmse_ShouldBe = 0.0270425329959
         model_r2adj_ShouldBe = 0.999837801207
         model_Fstat_ShouldBe = 30822.3699783
-        model_Fpv_ShouldBe = 3.33066907388e-16
+        model_Fpv_ShouldBe = 2.8349827407387309e-16
         model_ll_ShouldBe = 24.1054640542
         model_aic_ShouldBe = -3.83735710076
         model_bic_ShouldBe = -3.72884020818


### PR DESCRIPTION
Fixes #12.

`Fpv` was computed as `1.0 - scipy.stats.f.cdf(...)`. For the tiny upper-tail probabilities involved, that subtraction loses almost all precision to cancellation, and scipy 1.17 shifted `f.cdf` slightly in the tail, which flipped the `Fpv` assertion in `Test_CalculateCoefficientAndFitStatistics`.

Use `scipy.stats.f.sf(...)`, which computes the upper tail directly and is stable across scipy versions. Apply the same change to the coefficient p-values (`2 * scipy.stats.t.sf(|t|)`), which had the identical pattern.

Refresh the now-stale `Fpv` (UserDefinedFunction and Spline cases) and `pstat_beta` expected values in the test.

One correction to the issue. I originally said three checks fail. The test already applies looser tolerances to `sd_beta` (`rtol=1e-5`) and `pstat_beta` (`rtol=1e-4`), so only the `Fpv` assertion (`rtol=1e-6`) actually fails. My original check used a uniform `1e-6` by mistake. The `pstat_beta` change here is preventive rather than a current failure: it shares the same cancellation and would break on a future scipy the way `Fpv` did on 1.17.

* [x] I have read the guidelines in our [CONTRIBUTING.md](../main/CONTRIBUTING.md) document.
* [x] I have tested my new feature locally to ensure it is correct.
