### PR TITLE
add CI for unittests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,41 @@
+name: CI
+
+on: [push, pull_request, workflow_dispatch]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12", "3.13"]
+        numpy-version: ["<2", ">=2"]
+        exclude:
+        - python-version: "3.8"
+          numpy-version: ">=2"
+
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install "numpy${{ matrix.numpy-version }}"
+          pip install .[output]
+
+      # Optional: show versions for debugging
+      - name: Show environment
+        run: |
+          python --version
+          python -c "import numpy; print('NumPy:', numpy.__version__)"
+
+      - name: Run unittests
+        run: |
+          python -m unittest discover -s unittests -v


### PR DESCRIPTION
This pull request adds a new GitHub Actions workflow for continuous integration (CI) to automate testing across multiple Python and NumPy versions. The workflow ensures that the codebase is tested for compatibility with a range of Python (3.8–3.13) and NumPy (<2, >=2) versions.