### PR TITLE
Reconstruct a fitted spline from its stored coefficients

### DIFF
--- a/examples/Simple/RebuildSplineFromStoredCoefficients_3D.py
+++ b/examples/Simple/RebuildSplineFromStoredCoefficients_3D.py
@@ -1,0 +1,67 @@
+import pyeq3
+import numpy
+import json
+
+# A spline fit keeps its result in two places: solvedCoefficients (the spline
+# tck) and a live scipy spline object built during Solve(). The live object is
+# not JSON-serializable, so an application that stores a fit in a database or a
+# JSON session store can only persist solvedCoefficients and the spline orders.
+# This example saves those values as JSON, then rebuilds a working fit from them
+# with no live scipy object.
+
+
+# parameters are smoothing, xOrder, yOrder
+equation = pyeq3.Models_3D.Spline.Spline(1.0, 3, 3)  # cubic 3D spline
+data = equation.exampleData
+
+pyeq3.dataConvertorService().ConvertAndSortColumnarASCII(data, equation, False)
+equation.Solve()
+
+originalPredictions = equation.CalculateModelPredictions(
+    equation.solvedCoefficients, equation.dataCache.allDataCacheDictionary
+)
+
+
+##########################################################
+
+
+# Store the fit as JSON. For a 3D spline the tck does not include the spline
+# degrees, so the orders are saved alongside it; the model carries them as
+# xOrder and yOrder.
+xKnots, yKnots, coefficients = equation.solvedCoefficients
+stored = json.dumps(
+    {
+        "coefficients": [xKnots.tolist(), yKnots.tolist(), coefficients.tolist()],
+        "xOrder": equation.xOrder,
+        "yOrder": equation.yOrder,
+    }
+)
+
+
+##########################################################
+
+
+# Later, or in another process, rebuild a working spline from the stored JSON
+# alone. This fresh instance has never been solved and has no live scipy
+# object; CalculateModelPredictions reconstructs one on demand.
+loaded = json.loads(stored)
+
+reloaded = pyeq3.Models_3D.Spline.Spline()
+pyeq3.dataConvertorService().ConvertAndSortColumnarASCII(data, reloaded, False)
+reloaded.xOrder = loaded["xOrder"]
+reloaded.yOrder = loaded["yOrder"]
+reloaded.solvedCoefficients = loaded["coefficients"]
+
+# build the X/Y cache terms for the points to evaluate; Solve() normally does
+# this, so a reconstruct-only instance has to do it explicitly
+reloaded.dataCache.FindOrCreateAllDataCache(reloaded)
+
+rebuiltPredictions = reloaded.CalculateModelPredictions(
+    reloaded.solvedCoefficients, reloaded.dataCache.allDataCacheDictionary
+)
+
+
+print(
+    "predictions match after reconstruction:",
+    numpy.allclose(originalPredictions, rebuiltPredictions),
+)

--- a/pyeq3/Models_2D/Spline.py
+++ b/pyeq3/Models_2D/Spline.py
@@ -15,6 +15,9 @@ import inspect
 if os.path.join(sys.path[0][: sys.path[0].rfind(os.sep)], "..") not in sys.path:
     sys.path.append(os.path.join(sys.path[0][: sys.path[0].rfind(os.sep)], ".."))
 
+import numpy
+import scipy.interpolate
+
 import pyeq3
 import pyeq3.Model_2D_BaseClass
 
@@ -54,8 +57,30 @@ class Spline(pyeq3.Model_2D_BaseClass.Model_2D_BaseClass):
         return True  # splines do not have coefficient bounds
 
     def CalculateModelPredictions(self, inCoeffs, inDataCacheDictionary):
+        if getattr(self, "scipySpline", None) is None:
+            self.RebuildScipySpline()
         result = self.scipySpline(inDataCacheDictionary["X"])
         return result
+
+    def RebuildScipySpline(self):
+        # Rebuild the live scipy spline from solvedCoefficients when it was not
+        # produced in this process (e.g. a fit reloaded from storage). Here
+        # solvedCoefficients is the UnivariateSpline _eval_args tuple
+        # (knots, coefficients, degree). Rebuild the same UnivariateSpline type
+        # rather than a bare BSpline so consumers that read _eval_args (the
+        # source-code output) keep working, not just prediction. asarray/int
+        # restore the array/scalar types after a list-based reload (e.g. JSON).
+        knots, coefficients, degree = self.solvedCoefficients
+        spline = scipy.interpolate.UnivariateSpline.__new__(
+            scipy.interpolate.UnivariateSpline
+        )
+        spline._eval_args = (
+            numpy.asarray(knots),
+            numpy.asarray(coefficients),
+            int(degree),
+        )
+        spline.ext = 0  # extrapolate, matching UnivariateSpline's default
+        self.scipySpline = spline
 
     def GetCoefficientDesignators(self):
         raise NotImplementedError(

--- a/pyeq3/Models_3D/Spline.py
+++ b/pyeq3/Models_3D/Spline.py
@@ -15,6 +15,9 @@ import inspect
 if os.path.join(sys.path[0][: sys.path[0].rfind(os.sep)], "..") not in sys.path:
     sys.path.append(os.path.join(sys.path[0][: sys.path[0].rfind(os.sep)], ".."))
 
+import numpy
+import scipy.interpolate
+
 import pyeq3
 import pyeq3.Model_3D_BaseClass
 
@@ -57,10 +60,30 @@ class Spline(pyeq3.Model_3D_BaseClass.Model_3D_BaseClass):
         return True  # splines do not have coefficient bounds
 
     def CalculateModelPredictions(self, inCoeffs, inDataCacheDictionary):
+        if getattr(self, "scipySpline", None) is None:
+            self.RebuildScipySpline()
         result = self.scipySpline.ev(
             inDataCacheDictionary["X"], inDataCacheDictionary["Y"]
         )
         return result
+
+    def RebuildScipySpline(self):
+        # Rebuild the live scipy spline from solvedCoefficients when it was not
+        # produced in this process (e.g. a fit reloaded from storage). Here
+        # solvedCoefficients is SmoothBivariateSpline.tck, the
+        # (xKnots, yKnots, coefficients) tuple. The spline degrees are not
+        # stored in tck, so take them from the model's xOrder and yOrder.
+        xKnots, yKnots, coefficients = self.solvedCoefficients
+        spline = scipy.interpolate.SmoothBivariateSpline.__new__(
+            scipy.interpolate.SmoothBivariateSpline
+        )
+        spline.tck = (
+            numpy.asarray(xKnots),
+            numpy.asarray(yKnots),
+            numpy.asarray(coefficients),
+        )
+        spline.degrees = (int(self.xOrder), int(self.yOrder))
+        self.scipySpline = spline
 
     def GetCoefficientDesignators(self):
         raise NotImplementedError(

--- a/unittests/Test_ModelSolveMethods.py
+++ b/unittests/Test_ModelSolveMethods.py
@@ -1,5 +1,6 @@
 from . import DataForUnitTests
 import pyeq3
+import json
 import sys
 import os
 import unittest
@@ -108,6 +109,81 @@ class TestModelSolveMethods(unittest.TestCase):
             numpy.allclose(result[1], resultShouldBe[1], rtol=1.0e-06, atol=1.0e-300)
         )
         self.assertEqual(result[2], resultShouldBe[2])
+
+    def test_SplineReconstructionFromStoredCoefficients_2D(self):
+        # Simulate a fit reloaded from storage: a fresh instance that has only
+        # solvedCoefficients (round-tripped through JSON, so lists rather than
+        # the original numpy arrays) and no live scipy object. Rebuilding from
+        # the stored values must reproduce the predictions and keep the spline
+        # source-code emittable.
+        model = pyeq3.Models_2D.Spline.Spline(inSmoothingFactor=1.0, inXOrder=3)
+        pyeq3.dataConvertorService().ConvertAndSortColumnarASCII(
+            model.exampleData, model, False
+        )
+        model.Solve()
+        before = model.CalculateModelPredictions(
+            model.solvedCoefficients, model.dataCache.allDataCacheDictionary
+        )
+
+        knots, coeffs, degree = model.solvedCoefficients
+        stored = json.loads(json.dumps([knots.tolist(), coeffs.tolist(), int(degree)]))
+
+        reloaded = pyeq3.Models_2D.Spline.Spline()
+        pyeq3.dataConvertorService().ConvertAndSortColumnarASCII(
+            model.exampleData, reloaded, False
+        )
+        reloaded.solvedCoefficients = stored
+        reloaded.dataCache.FindOrCreateAllDataCache(reloaded)
+        after = reloaded.CalculateModelPredictions(
+            reloaded.solvedCoefficients, reloaded.dataCache.allDataCacheDictionary
+        )
+        self.assertTrue(numpy.allclose(after, before, rtol=1.0e-10, atol=1.0e-300))
+
+        # source-code output reads UnivariateSpline._eval_args; a bare BSpline
+        # would not have it, so this also guards the reconstructed object type
+        sourceCode = pyeq3.outputSourceCodeService().GetOutputSourceCodePYTHON(reloaded)
+        self.assertTrue(len(sourceCode) > 0)
+
+    def test_SplineReconstructionFromStoredCoefficients_3D(self):
+        # Same reload for the bivariate surface. The 3D tck carries no degrees,
+        # so the rebuild also needs the stored xOrder and yOrder.
+        model = pyeq3.Models_3D.Spline.Spline(
+            inSmoothingFactor=1.0, inXOrder=2, inYOrder=2
+        )
+        pyeq3.dataConvertorService().ConvertAndSortColumnarASCII(
+            model.exampleData, model, False
+        )
+        model.Solve()
+        before = model.CalculateModelPredictions(
+            model.solvedCoefficients, model.dataCache.allDataCacheDictionary
+        )
+
+        xKnots, yKnots, coeffs = model.solvedCoefficients
+        stored = json.loads(
+            json.dumps(
+                {
+                    "coefficients": [xKnots.tolist(), yKnots.tolist(), coeffs.tolist()],
+                    "xOrder": model.xOrder,
+                    "yOrder": model.yOrder,
+                }
+            )
+        )
+
+        reloaded = pyeq3.Models_3D.Spline.Spline()
+        pyeq3.dataConvertorService().ConvertAndSortColumnarASCII(
+            model.exampleData, reloaded, False
+        )
+        reloaded.xOrder = stored["xOrder"]
+        reloaded.yOrder = stored["yOrder"]
+        reloaded.solvedCoefficients = stored["coefficients"]
+        reloaded.dataCache.FindOrCreateAllDataCache(reloaded)
+        after = reloaded.CalculateModelPredictions(
+            reloaded.solvedCoefficients, reloaded.dataCache.allDataCacheDictionary
+        )
+        self.assertTrue(numpy.allclose(after, before, rtol=1.0e-10, atol=1.0e-300))
+
+        sourceCode = pyeq3.outputSourceCodeService().GetOutputSourceCodePYTHON(reloaded)
+        self.assertTrue(len(sourceCode) > 0)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Closes #17.

For more details, see #17 and #11. You can save scipy spline objects with pickle, but not as JSON. Because of this, apps like zunzun-ng that use JSON can only save `solvedCoefficients` and the spline orders. Right now, a fitted `Spline` cannot make predictions using only these saved values because `CalculateModelPredictions` needs the active `scipySpline` object created during `Solve()`.

With this update, a fitted spline can now describe itself as other models can. If the active object is missing, `CalculateModelPredictions` can recreate it from `solvedCoefficients` when needed.

- For 2D splines, `solvedCoefficients` is `UnivariateSpline._eval_args`, which includes `(knots, coeffs, degree)`, so the same `UnivariateSpline` type is rebuilt from these values.
- For 3D splines, `solvedCoefficients` is `SmoothBivariateSpline.tck`, which contains `(tx, ty, c)`. Since `tck` does not include the degrees, the recreation uses the model's `xOrder` and `yOrder`.

This update is additive. When an active `scipySpline` is available after each `Solve()`, the code works as it did before. The format of `solvedCoefficients` stays the same, so all existing tests and source-code output remain unchanged.

### For changes of existing features:

* [x] I have tested my new feature locally to ensure it is correct. Two reconstruction tests in `Test_ModelSolveMethods.py` (solve, reload the coefficients into a fresh instance through a JSON round-trip, predict, and assert the predictions match and the rebuilt spline still emits source code); the full registered suite passes (121 tests).
* [x] I have created an example in the [examples/](../main/examples/) directory: `examples/Simple/RebuildSplineFromStoredCoefficients_3D.py`.
