### PR TITLE
Added autoindentation script

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,6 +3,34 @@ name: CI
 on: [push, pull_request, workflow_dispatch]
 
 jobs:
+  indent:
+    name: indent
+    runs-on: [ubuntu-24.04]
+
+    strategy:
+      matrix:
+        python-versions: ['3.13']
+
+    steps:
+    - uses: actions/checkout@v4
+    - name: Set up Python ${{ matrix.python-versions }}
+      uses: actions/setup-python@v4
+      with:
+        python-version: ${{ matrix.python-versions }}
+    - name: make indent
+      run: |
+        python -m pip install black
+        ./contrib/utilities/indent
+        git diff > changes-astyle.diff
+    - name: archive indent results
+      uses: actions/upload-artifact@v4
+      with:
+        name: changes-astyle.diff
+        path: changes-astyle.diff
+    - name: check indentation
+      run: |
+        git diff --exit-code
+
   test:
     runs-on: ubuntu-latest
 

--- a/contrib/utilities/indent
+++ b/contrib/utilities/indent
@@ -1,0 +1,76 @@
+#!/bin/bash
+## ---------------------------------------------------------------------
+## This file is part of pyeq3,
+## a collection of Python equations and curve fitting tools.
+## ---------------------------------------------------------------------
+
+
+if test ! -d pyeq3 -o ! -d unittests -o ! -d examples ; then
+  echo "*** This script must be run from the top-level directory of pyeq3."
+  exit 1
+fi
+
+
+# collect all source files and process them in batches of 50 files
+# with up to 10 in parallel
+echo "--- Indenting all pyeq3 header and source files"
+
+# Run black autoformatter
+find pyeq3 contrib examples unittests \( -name '*.py' \) -print | xargs -n 1 -P 10 -I {} bash -c 'black "$@"' _ {}
+
+# remove execute permission on source files:
+find pyeq3 contrib examples unittests \( -name '*.py' \) -print | xargs -n 50 -P 10 chmod -x
+
+# convert dos formatted files to unix file format by stripping out
+# carriage returns (15=0x0D):
+dos_to_unix()
+{
+    f=$1
+    tr -d '\015' <$f >$f.tmp
+    diff -q $f $f.tmp >/dev/null || mv $f.tmp $f
+    rm -f $f.tmp
+}
+export -f dos_to_unix
+find pyeq3 contrib examples unittests \( -name '*.py' \) -print | xargs -n 1 -P 10 -I {} bash -c 'dos_to_unix "$@"' _ {}
+
+
+# Remove trailing whitespace from files
+remove_trailing_whitespace()
+{
+    f=$1
+    # awkward tab replacement because of OSX sed, do not change unless you test it on OSX
+    TAB=$'\t'
+    sed -e "s/[ $TAB]*$//"  $f >$f.tmp
+    diff -q $f $f.tmp >/dev/null || mv $f.tmp $f
+    rm -f $f.tmp
+}
+export -f remove_trailing_whitespace
+find pyeq3 contrib examples unittests \( -name '*.py' \) -print | xargs -n 1 -P 10 -I {} bash -c 'remove_trailing_whitespace "$@"' _ {}
+
+# Ensure only a single newline at end of files
+ensure_single_trailing_newline()
+{
+  f=$1
+
+  # Remove newlines at end of file
+  # Check that the current line only contains newlines
+  # If it doesn't match, print it
+  # If it does match and we're not at the end of the file,
+  # append the next line to the current line and repeat the check
+  # If it does match and we're at the end of the file,
+  # remove the line.
+  sed -e :a -e '/^\n*$/{$d;N;};/\n$/ba' $f >$f.tmpi
+
+  # Then add a newline to the end of the file
+  # '$' denotes the end of file
+  # 'a\' appends the following text (which in this case is nothing)
+  # on a new line
+  sed -e '$a\' $f.tmpi >$f.tmp
+
+  diff -q $f $f.tmp >/dev/null || mv $f.tmp $f
+  rm -f $f.tmp $f.tmpi
+}
+export -f ensure_single_trailing_newline
+find pyeq3 contrib examples unittests \( -name '*.py' \) -print | xargs -n 1 -P 10 -I {} bash -c 'ensure_single_trailing_newline "$@"' _ {}
+
+exit 0

--- a/examples/Cluster/FitAllEquations_2D.py
+++ b/examples/Cluster/FitAllEquations_2D.py
@@ -3,7 +3,6 @@ import dispy
 
 import pyeq3
 
-
 # Standard lowest sum-of-squared errors in this example,
 # see IModel.fittingTargetDictionary
 fittingTargetString = "SSQABS"

--- a/examples/Cluster/FitAllEquations_3D.py
+++ b/examples/Cluster/FitAllEquations_3D.py
@@ -3,7 +3,6 @@ import dispy
 
 import pyeq3
 
-
 # Standard lowest sum-of-squared errors in this example,
 # see IModel.fittingTargetDictionary
 fittingTargetString = "SSQABS"

--- a/examples/Complex/FitAllEquationsInSeries_LargeResultList_2D.py
+++ b/examples/Complex/FitAllEquationsInSeries_LargeResultList_2D.py
@@ -166,9 +166,9 @@ for submodule in inspect.getmembers(pyeq3.Models_2D):
                         equationInstance.numberOfReducedDataPoints
                         not in reducedDataCache
                     ):
-                        reducedDataCache[
-                            equationInstance.numberOfReducedDataPoints
-                        ] = equationInstance.dataCache.reducedDataCacheDictionary
+                        reducedDataCache[equationInstance.numberOfReducedDataPoints] = (
+                            equationInstance.dataCache.reducedDataCacheDictionary
+                        )
 
 
 ##########################
@@ -213,9 +213,9 @@ for coeffCount in range(1, maxPolyfunctionalCoefficients + 1):
         SetParametersAndFit(equationInstance, resultList, False)
 
         if equationInstance.numberOfReducedDataPoints not in reducedDataCache:
-            reducedDataCache[
-                equationInstance.numberOfReducedDataPoints
-            ] = equationInstance.dataCache.reducedDataCacheDictionary
+            reducedDataCache[equationInstance.numberOfReducedDataPoints] = (
+                equationInstance.dataCache.reducedDataCacheDictionary
+            )
 
         equationCount += 1
         if (equationCount % 250) == 0:
@@ -254,9 +254,9 @@ for polynomialOrderX in range(maxPolynomialOrderX + 1):
     SetParametersAndFit(equationInstance, resultList, False)
 
     if equationInstance.numberOfReducedDataPoints not in reducedDataCache:
-        reducedDataCache[
-            equationInstance.numberOfReducedDataPoints
-        ] = equationInstance.dataCache.reducedDataCacheDictionary
+        reducedDataCache[equationInstance.numberOfReducedDataPoints] = (
+            equationInstance.dataCache.reducedDataCacheDictionary
+        )
 
 
 ######################
@@ -320,9 +320,9 @@ for numeratorCoeffCount in range(1, maxCoeffs):
                         equationInstance.numberOfReducedDataPoints
                         not in reducedDataCache
                     ):
-                        reducedDataCache[
-                            equationInstance.numberOfReducedDataPoints
-                        ] = equationInstance.dataCache.reducedDataCacheDictionary
+                        reducedDataCache[equationInstance.numberOfReducedDataPoints] = (
+                            equationInstance.dataCache.reducedDataCacheDictionary
+                        )
 
                     equationCount += 1
                     if (equationCount % 5) == 0:

--- a/examples/Complex/FitAllEquationsInSeries_LargeResultList_3D.py
+++ b/examples/Complex/FitAllEquationsInSeries_LargeResultList_3D.py
@@ -172,9 +172,9 @@ for submodule in inspect.getmembers(pyeq3.Models_3D):
                         equationInstance.numberOfReducedDataPoints
                         not in reducedDataCache
                     ):
-                        reducedDataCache[
-                            equationInstance.numberOfReducedDataPoints
-                        ] = equationInstance.dataCache.reducedDataCacheDictionary
+                        reducedDataCache[equationInstance.numberOfReducedDataPoints] = (
+                            equationInstance.dataCache.reducedDataCacheDictionary
+                        )
 
 
 # Sort the result list by fitting target value

--- a/examples/Complex/FitAllEquationsInSeries_NoResultList_2D.py
+++ b/examples/Complex/FitAllEquationsInSeries_NoResultList_2D.py
@@ -178,9 +178,9 @@ for submodule in inspect.getmembers(pyeq3.Models_2D):
                         equationInstance.numberOfReducedDataPoints
                         not in reducedDataCache
                     ):
-                        reducedDataCache[
-                            equationInstance.numberOfReducedDataPoints
-                        ] = equationInstance.dataCache.reducedDataCacheDictionary
+                        reducedDataCache[equationInstance.numberOfReducedDataPoints] = (
+                            equationInstance.dataCache.reducedDataCacheDictionary
+                        )
 
 
 ##########################
@@ -227,9 +227,9 @@ for coeffCount in range(1, maxPolyfunctionalCoefficients + 1):
             bestResult = result
 
         if equationInstance.numberOfReducedDataPoints not in reducedDataCache:
-            reducedDataCache[
-                equationInstance.numberOfReducedDataPoints
-            ] = equationInstance.dataCache.reducedDataCacheDictionary
+            reducedDataCache[equationInstance.numberOfReducedDataPoints] = (
+                equationInstance.dataCache.reducedDataCacheDictionary
+            )
 
         equationCount += 1
         if (equationCount % 250) == 0:
@@ -270,9 +270,9 @@ for polynomialOrderX in range(maxPolynomialOrderX + 1):
         bestResult = result
 
     if equationInstance.numberOfReducedDataPoints not in reducedDataCache:
-        reducedDataCache[
-            equationInstance.numberOfReducedDataPoints
-        ] = equationInstance.dataCache.reducedDataCacheDictionary
+        reducedDataCache[equationInstance.numberOfReducedDataPoints] = (
+            equationInstance.dataCache.reducedDataCacheDictionary
+        )
 
 
 ######################
@@ -339,9 +339,9 @@ for numeratorCoeffCount in range(1, maxCoeffs):
                         equationInstance.numberOfReducedDataPoints
                         not in reducedDataCache
                     ):
-                        reducedDataCache[
-                            equationInstance.numberOfReducedDataPoints
-                        ] = equationInstance.dataCache.reducedDataCacheDictionary
+                        reducedDataCache[equationInstance.numberOfReducedDataPoints] = (
+                            equationInstance.dataCache.reducedDataCacheDictionary
+                        )
 
                     equationCount += 1
                     if (equationCount % 5) == 0:

--- a/examples/Complex/FitUsingMultipleNonlinearSolvers_2D.py
+++ b/examples/Complex/FitUsingMultipleNonlinearSolvers_2D.py
@@ -307,9 +307,9 @@ for coeffCount in range(1, maxPolyfunctionalCoefficients + 1):
                     print()
 
             if equationInstance.numberOfReducedDataPoints not in reducedDataCache:
-                reducedDataCache[
-                    equationInstance.numberOfReducedDataPoints
-                ] = equationInstance.dataCache.reducedDataCacheDictionary
+                reducedDataCache[equationInstance.numberOfReducedDataPoints] = (
+                    equationInstance.dataCache.reducedDataCacheDictionary
+                )
 
         equationCount += 1
         if (equationCount % 250) == 0:
@@ -378,9 +378,9 @@ for polynomialOrderX in range(maxPolynomialOrderX + 1):
                 print()
 
         if equationInstance.numberOfReducedDataPoints not in reducedDataCache:
-            reducedDataCache[
-                equationInstance.numberOfReducedDataPoints
-            ] = equationInstance.dataCache.reducedDataCacheDictionary
+            reducedDataCache[equationInstance.numberOfReducedDataPoints] = (
+                equationInstance.dataCache.reducedDataCacheDictionary
+            )
 
 
 ######################

--- a/examples/List/ListAllExtendedVersionsOfEquations_2D.py
+++ b/examples/List/ListAllExtendedVersionsOfEquations_2D.py
@@ -4,7 +4,6 @@ import inspect
 
 import pyeq3
 
-
 for submodule in inspect.getmembers(pyeq3.Models_2D):
     if inspect.ismodule(submodule[1]):
         for equationClass in inspect.getmembers(submodule[1]):

--- a/examples/List/ListAllExtendedVersionsOfEquations_3D.py
+++ b/examples/List/ListAllExtendedVersionsOfEquations_3D.py
@@ -4,7 +4,6 @@ import inspect
 
 import pyeq3
 
-
 for submodule in inspect.getmembers(pyeq3.Models_3D):
     if inspect.ismodule(submodule[1]):
         for equationClass in inspect.getmembers(submodule[1]):

--- a/examples/List/ListAllStandardEquations_2D.py
+++ b/examples/List/ListAllStandardEquations_2D.py
@@ -4,7 +4,6 @@ import inspect
 
 import pyeq3
 
-
 for submodule in inspect.getmembers(pyeq3.Models_2D):
     if inspect.ismodule(submodule[1]):
         for equationClass in inspect.getmembers(submodule[1]):

--- a/examples/List/ListAllStandardEquations_3D.py
+++ b/examples/List/ListAllStandardEquations_3D.py
@@ -4,7 +4,6 @@ import inspect
 
 import pyeq3
 
-
 for submodule in inspect.getmembers(pyeq3.Models_3D):
     if inspect.ismodule(submodule[1]):
         for equationClass in inspect.getmembers(submodule[1]):

--- a/examples/NodeJS/generator.py
+++ b/examples/NodeJS/generator.py
@@ -1,6 +1,5 @@
 import inspect
 
-
 # named equations only
 for modelsTypeName in ["Models_2D", "Models_3D"]:
     modelsFile = open(modelsTypeName + ".js", "wt")

--- a/examples/Parallel/FitAllEquationsInParallel_NoResultList_2D.py
+++ b/examples/Parallel/FitAllEquationsInParallel_NoResultList_2D.py
@@ -159,9 +159,9 @@ def ParallelFittingFunction(
                 bestResult = result
 
             if equationInstance.numberOfReducedDataPoints not in reducedDataCache:
-                reducedDataCache[
-                    equationInstance.numberOfReducedDataPoints
-                ] = equationInstance.dataCache.reducedDataCacheDictionary
+                reducedDataCache[equationInstance.numberOfReducedDataPoints] = (
+                    equationInstance.dataCache.reducedDataCacheDictionary
+                )
 
             equationCount += 1
             if (equationCount % 50) == 0:
@@ -212,9 +212,9 @@ def ParallelFittingFunction(
             bestResult = result
 
         if equationInstance.numberOfReducedDataPoints not in reducedDataCache:
-            reducedDataCache[
-                equationInstance.numberOfReducedDataPoints
-            ] = equationInstance.dataCache.reducedDataCacheDictionary
+            reducedDataCache[equationInstance.numberOfReducedDataPoints] = (
+                equationInstance.dataCache.reducedDataCacheDictionary
+            )
 
     ######################
     # fit user-selectable rationals here

--- a/examples/Simple/CoefficientBounds_2D.py
+++ b/examples/Simple/CoefficientBounds_2D.py
@@ -1,6 +1,5 @@
 import pyeq3
 
-
 equation = pyeq3.Models_2D.Polynomial.Linear()
 
 pyeq3.dataConvertorService().ConvertAndSortColumnarASCII(

--- a/examples/Simple/CreateExtendedVersionOfOneNamedEquation_2D.py
+++ b/examples/Simple/CreateExtendedVersionOfOneNamedEquation_2D.py
@@ -1,6 +1,5 @@
 import pyeq3
 
-
 # print all possible extended version names
 print("List of all possible extended version names")
 for extendedVersionName in pyeq3.ExtendedVersionHandlers.extendedVersionHandlerNameList:

--- a/examples/Simple/EstimatedInitialCoefficients_3D.py
+++ b/examples/Simple/EstimatedInitialCoefficients_3D.py
@@ -1,6 +1,5 @@
 import pyeq3
 
-
 # see IModel.fittingTargetDictionary
 equation = pyeq3.Models_3D.BioScience.HighLowAffinityIsotopeDisplacement("SSQABS")
 

--- a/examples/Simple/FitOneNamedEquation_2D.py
+++ b/examples/Simple/FitOneNamedEquation_2D.py
@@ -1,6 +1,5 @@
 import pyeq3
 
-
 # see IModel.fittingTargetDictionary
 equation = pyeq3.Models_2D.BioScience.HyperbolicLogistic()  # SSQABS by default
 

--- a/examples/Simple/FitOneNamedEquation_3D.py
+++ b/examples/Simple/FitOneNamedEquation_3D.py
@@ -1,6 +1,5 @@
 import pyeq3
 
-
 # see IModel.fittingTargetDictionary
 equation = pyeq3.Models_3D.Polynomial.SimplifiedQuadratic("SSQABS")
 

--- a/examples/Simple/FitUserData_2D.py
+++ b/examples/Simple/FitUserData_2D.py
@@ -1,6 +1,5 @@
 import pyeq3
 
-
 # see IModel.fittingTargetDictionary
 equation = pyeq3.Models_2D.BioScience.HyperbolicLogistic("SSQABS")
 

--- a/examples/Simple/FitUserDefinedFunction_2D.py
+++ b/examples/Simple/FitUserDefinedFunction_2D.py
@@ -1,6 +1,5 @@
 import pyeq3
 
-
 functionString = "m*X+B * (3/2)"
 
 # note that the constructor is passed the function string here

--- a/examples/Simple/FitWeightedData_2D.py
+++ b/examples/Simple/FitWeightedData_2D.py
@@ -1,6 +1,5 @@
 import pyeq3
 
-
 # see IModel.fittingTargetDictionary
 equation = pyeq3.Models_2D.Polynomial.Linear("SSQABS")
 

--- a/examples/Simple/FixedCoefficient_3D.py
+++ b/examples/Simple/FixedCoefficient_3D.py
@@ -1,6 +1,5 @@
 import pyeq3
 
-
 # see IModel.fittingTargetDictionary
 equation = pyeq3.Models_3D.BioScience.HighLowAffinityIsotopeDisplacement("SSQABS")
 

--- a/examples/Simple/Spline_3D.py
+++ b/examples/Simple/Spline_3D.py
@@ -1,6 +1,5 @@
 import pyeq3
 
-
 # parameters are smoothing, xOrder, yOrder
 equation = pyeq3.Models_3D.Spline.Spline(1.0, 3, 3)  # cubic 3D spline
 

--- a/pyeq3/Services/SolverService.py
+++ b/pyeq3/Services/SolverService.py
@@ -272,9 +272,7 @@ class SolverService(object):
         ydata = inModel.dataCache.allDataCacheDictionary["DependentData"]
         weights = inModel.dataCache.allDataCacheDictionary["Weights"]
         weight_y = weights if len(weights) else None
-        maxit = (
-            len(inModel.GetCoefficientDesignators()) * self.fminIterationLimit
-        )
+        maxit = len(inModel.GetCoefficientDesignators()) * self.fminIterationLimit
 
         results = []
 
@@ -364,7 +362,7 @@ class SolverService(object):
             list1 = data[0]
             list2 = inModel.dataCache.allDataCacheDictionary["DependentData"]
 
-            (list1, list2) = [
+            list1, list2 = [
                 list(x)
                 for x in zip(*sorted(zip(list1, list2), key=lambda pair: pair[0]))
             ]

--- a/pyeq3/Utilities/Multifit.py
+++ b/pyeq3/Utilities/Multifit.py
@@ -227,13 +227,9 @@ def SubmitTasksToQueue(
     maxPolyfunctionalCoefficients = smoothnessControl
 
     if inDimension == 2:
-        polyfunctionalEquationList = (
-            PolyFunctions.GenerateListForPolyfunctionals_2D()
-        )
+        polyfunctionalEquationList = PolyFunctions.GenerateListForPolyfunctionals_2D()
     else:
-        polyfunctionalEquationList = (
-            PolyFunctions.GenerateListForPolyfunctionals_3D()
-        )
+        polyfunctionalEquationList = PolyFunctions.GenerateListForPolyfunctionals_3D()
 
     # make a list of function indices to permute
     functionIndexList = list(range(len(polyfunctionalEquationList)))


### PR DESCRIPTION
This pull request automates code indentation, formatting, and whitespace cleanup for Python files:

* Added a new script in contrib/utilities/indent that autoformats all Python files using `black`, removes execute permissions, converts DOS line endings to Unix, strips trailing whitespace, and ensures a single trailing newline at the end of each file. 
* Added a new `indent` job to the GitHub Actions CI workflow (`.github/workflows/ci.yml`). The results are archived and the job fails if any files are not properly formatted.
* Runs the script on existing files