### PR TITLE
reworded spline retrieval functions and docstrings

### DIFF
--- a/examples/Simple/RebuildSplineFromStoredCoefficients_3D.py
+++ b/examples/Simple/RebuildSplineFromStoredCoefficients_3D.py
@@ -6,11 +6,10 @@ import json
 # tck) and a live scipy spline object built during Solve(). The live object is
 # not JSON-serializable, so an application that stores a fit in a database or a
 # JSON session store can only persist solvedCoefficients and the spline orders.
-# This example saves those values as JSON, then rebuilds a working fit from them
-# with no live scipy object.
+# This example saves those values as JSON, then rebuilds a working fit from
+# them with no live scipy object.
 
-
-# parameters are smoothing, xOrder, yOrder
+# arguments passed to the 3D spline constructor are smoothing, xOrder, yOrder
 equation = pyeq3.Models_3D.Spline.Spline(1.0, 3, 3)  # cubic 3D spline
 data = equation.exampleData
 
@@ -21,13 +20,12 @@ originalPredictions = equation.CalculateModelPredictions(
     equation.solvedCoefficients, equation.dataCache.allDataCacheDictionary
 )
 
-
-##########################################################
-
-
-# Store the fit as JSON. For a 3D spline the tck does not include the spline
-# degrees, so the orders are saved alongside it; the model carries them as
-# xOrder and yOrder.
+# We can store the optimized spline as a JSON.
+# For a 3D spline the solvedCoefficients (tck)
+# is a tuple of three arrays: xKnots, yKnots, and coefficients.
+# These arrays do not include the spline orders which
+# are needed to reconstruct the spline, so we extract those
+# from xOrder and yOrder and store them alongside the tck in the JSON.
 xKnots, yKnots, coefficients = equation.solvedCoefficients
 stored = json.dumps(
     {
@@ -37,20 +35,20 @@ stored = json.dumps(
     }
 )
 
-
-##########################################################
-
-
-# Later, or in another process, rebuild a working spline from the stored JSON
-# alone. This fresh instance has never been solved and has no live scipy
+# Later, or in another process, rebuild the spline from the stored JSON
+# This fresh instance ("reloaded") has never been solved and has no live scipy
 # object; CalculateModelPredictions reconstructs one on demand.
 loaded = json.loads(stored)
 
 reloaded = pyeq3.Models_3D.Spline.Spline()
-pyeq3.dataConvertorService().ConvertAndSortColumnarASCII(data, reloaded, False)
 reloaded.xOrder = loaded["xOrder"]
 reloaded.yOrder = loaded["yOrder"]
 reloaded.solvedCoefficients = loaded["coefficients"]
+
+# we have to load the data into the reloaded instance so that it can build the
+# cache terms that CalculateModelPredictions needs; Solve() normally does this,
+# so a reconstruct-only instance has to do it explicitly
+pyeq3.dataConvertorService().ConvertAndSortColumnarASCII(data, reloaded, False)
 
 # build the X/Y cache terms for the points to evaluate; Solve() normally does
 # this, so a reconstruct-only instance has to do it explicitly

--- a/pyeq3/Models_2D/Spline.py
+++ b/pyeq3/Models_2D/Spline.py
@@ -58,22 +58,22 @@ class Spline(pyeq3.Model_2D_BaseClass.Model_2D_BaseClass):
 
     def CalculateModelPredictions(self, inCoeffs, inDataCacheDictionary):
         if getattr(self, "scipySpline", None) is None:
-            self.RebuildScipySpline()
+            self.BuildSplineFromSolvedCoefficients()
         result = self.scipySpline(inDataCacheDictionary["X"])
         return result
 
-    def RebuildScipySpline(self):
-        # Rebuild the live scipy spline from solvedCoefficients when it was not
-        # produced in this process (e.g. a fit reloaded from storage). Here
+    def BuildSplineFromSolvedCoefficients(self):
+        """
+        Build a scipy UnivariateSpline spline from solvedCoefficients.
+        """
         # solvedCoefficients is the UnivariateSpline _eval_args tuple
-        # (knots, coefficients, degree). Rebuild the same UnivariateSpline type
-        # rather than a bare BSpline so consumers that read _eval_args (the
-        # source-code output) keep working, not just prediction. asarray/int
-        # restore the array/scalar types after a list-based reload (e.g. JSON).
+        # (knots, coefficients, degree).
         knots, coefficients, degree = self.solvedCoefficients
         spline = scipy.interpolate.UnivariateSpline.__new__(
             scipy.interpolate.UnivariateSpline
         )
+
+        # restore the array/scalar types after a list-based reload (e.g. JSON).
         spline._eval_args = (
             numpy.asarray(knots),
             numpy.asarray(coefficients),

--- a/pyeq3/Models_3D/Spline.py
+++ b/pyeq3/Models_3D/Spline.py
@@ -61,15 +61,16 @@ class Spline(pyeq3.Model_3D_BaseClass.Model_3D_BaseClass):
 
     def CalculateModelPredictions(self, inCoeffs, inDataCacheDictionary):
         if getattr(self, "scipySpline", None) is None:
-            self.RebuildScipySpline()
+            self.BuildSplineFromSolvedCoefficients()
         result = self.scipySpline.ev(
             inDataCacheDictionary["X"], inDataCacheDictionary["Y"]
         )
         return result
 
-    def RebuildScipySpline(self):
-        # Rebuild the live scipy spline from solvedCoefficients when it was not
-        # produced in this process (e.g. a fit reloaded from storage). Here
+    def BuildSplineFromSolvedCoefficients(self):
+        """
+        Build a scipy SmoothBivariateSpline spline from solvedCoefficients.
+        """
         # solvedCoefficients is SmoothBivariateSpline.tck, the
         # (xKnots, yKnots, coefficients) tuple. The spline degrees are not
         # stored in tck, so take them from the model's xOrder and yOrder.

--- a/pyeq3/Services/DataConverterService.py
+++ b/pyeq3/Services/DataConverterService.py
@@ -31,6 +31,10 @@ class DataConverterService(object):
 
     # data is in columns
     def ConvertAndSortColumnarASCII(self, inRawData, inModel, inUseWeightsFlag):
+        """
+        Converts and sorts columnar ASCII data and updates the model object
+        with that processed data.
+        """
         # you should first process commas before calling this method,
         # as it uses the default token delimiters in string split()
         #

--- a/unittests/Test_ModelSolveMethods.py
+++ b/unittests/Test_ModelSolveMethods.py
@@ -112,10 +112,10 @@ class TestModelSolveMethods(unittest.TestCase):
 
     def test_SplineReconstructionFromStoredCoefficients_2D(self):
         # Simulate a fit reloaded from storage: a fresh instance that has only
-        # solvedCoefficients (round-tripped through JSON, so lists rather than
-        # the original numpy arrays) and no live scipy object. Rebuilding from
-        # the stored values must reproduce the predictions and keep the spline
-        # source-code emittable.
+        # solvedCoefficients as lists rather than the original numpy arrays,
+        # and no live scipy spline object. Rebuilding from
+        # the stored values must reproduce the predictions and
+        # allow the source-code output service to work.
         model = pyeq3.Models_2D.Spline.Spline(inSmoothingFactor=1.0, inXOrder=3)
         pyeq3.dataConvertorService().ConvertAndSortColumnarASCII(
             model.exampleData, model, False


### PR DESCRIPTION
This pull request:

* Renamed the method `RebuildScipySpline` to `BuildSplineFromSolvedCoefficients` in both `pyeq3/Models_2D/Spline.py` and `pyeq3/Models_3D/Spline.py`, and updated internal calls to use the new method name. The new docstrings clarify their purpose and the type of spline they reconstruct.
* Modified the docstrings in `examples/Simple/RebuildSplineFromStoredCoefficients_3D.py`, `pyeq3/Services/DataConverterService.py`, `unittests/Test_ModelSolveMethods.py`.