### PR TITLE
Fix numpy-array estimatedCoefficients crash and document the solvedCoefficients contract

### DIFF
--- a/pyeq3/IModel.py
+++ b/pyeq3/IModel.py
@@ -20,6 +20,33 @@ numpy.seterr(all="ignore")
 
 
 class IModel(object):
+    """Abstract base class for all pyeq3 equations.
+
+    Coefficient attribute contracts
+    -------------------------------
+    estimatedCoefficients : list or numpy.ndarray
+        Optional starting values for the non-linear and ODR solvers. A Python
+        list or a numpy array is accepted; an empty value (the default ``[]``)
+        means "no initial estimate", in which case Differential Evolution
+        supplies the starting point.
+
+    solvedCoefficients : numpy.ndarray or tuple
+        Assigned by ``Solve()``. For every analytic equation this is a
+        one-dimensional ``numpy.ndarray`` of floats whose length equals
+        ``len(self.GetCoefficientDesignators())``. For spline models
+        (``splineFlag is True``) it is instead the scipy spline ``tck``
+        representation, not a coefficient array:
+
+        * 2D: ``UnivariateSpline._eval_args`` == ``(knots, coefficients, degree)``
+        * 3D: ``SmoothBivariateSpline.tck`` == ``(xKnots, yKnots, coefficients)``;
+          the spline degrees are ``(xOrder, yOrder)`` and are not part of the
+          tuple.
+
+        Branch on ``splineFlag`` to distinguish the two cases, and use
+        ``BuildSplineFromSolvedCoefficients()`` to rebuild the live scipy
+        spline object.
+    """
+
     splineFlag = False
     userSelectablePolynomialFlag = False
     userCustomizablePolynomialFlag = False

--- a/pyeq3/Services/SolverService.py
+++ b/pyeq3/Services/SolverService.py
@@ -141,7 +141,7 @@ class SolverService(object):
         numpy.random.shuffle(pop0)
         pop0 = pop0.reshape(oneThirdOfPopulationSizeForGA * 3, numberOfCoefficients)
 
-        if inModel.estimatedCoefficients != []:
+        if len(inModel.estimatedCoefficients) > 0:
             # DE will overwrite these values, so use deepcopy
             pop0[0] = copy.deepcopy(inModel.estimatedCoefficients)
 

--- a/unittests/Test_SolverService.py
+++ b/unittests/Test_SolverService.py
@@ -150,6 +150,22 @@ class TestSolverService(unittest.TestCase):
             )
         )
 
+    def test_SolveUsingDE_emptyNumpyArrayEstimate_doesNotRaise(self):
+        # Regression for issue #16: assigning an EMPTY numpy array to
+        # estimatedCoefficients used to crash on the DE path. The check
+        # `if inModel.estimatedCoefficients != []` evaluated
+        # `numpy.array([]) != []`, which is an empty bool array, and `if`
+        # on it raises "The truth value of an empty array is ambiguous".
+        model = pyeq3.Models_2D.UserDefinedFunction.UserDefinedFunction(
+            "SSQABS", "Default", "m*X + b"
+        )
+        model.estimatedCoefficients = numpy.array([])
+        pyeq3.dataConvertorService().ConvertAndSortColumnarASCII(
+            DataForUnitTests.asciiDataInColumns_2D_small, model, False
+        )
+        coefficients = pyeq3.solverService().SolveUsingDE(model)
+        self.assertEqual(len(coefficients), 2)
+
     def test_SolveUsingSpline_3D(self):
         xKnotPointsShouldBe = numpy.array([0.607, 0.607, 0.607, 3.017, 3.017, 3.017])
         yKnotPointsShouldBe = numpy.array([1.984, 1.984, 1.984, 3.153, 3.153, 3.153])

--- a/unittests/Test_SolverService.py
+++ b/unittests/Test_SolverService.py
@@ -166,6 +166,35 @@ class TestSolverService(unittest.TestCase):
         coefficients = pyeq3.solverService().SolveUsingDE(model)
         self.assertEqual(len(coefficients), 2)
 
+    def test_solvedCoefficients_isOneDimensionalNumpyArray_forAnalyticModel(self):
+        # Contract: after Solve(), an analytic equation's solvedCoefficients
+        # is a 1-D numpy array of floats, one entry per coefficient designator.
+        model = pyeq3.Models_2D.Polynomial.Linear("SSQABS")
+        pyeq3.dataConvertorService().ConvertAndSortColumnarASCII(
+            DataForUnitTests.asciiDataInColumns_2D, model, False
+        )
+        model.Solve()
+        self.assertFalse(model.splineFlag)
+        self.assertIsInstance(model.solvedCoefficients, numpy.ndarray)
+        self.assertEqual(model.solvedCoefficients.ndim, 1)
+        self.assertEqual(
+            len(model.solvedCoefficients),
+            len(model.GetCoefficientDesignators()),
+        )
+
+    def test_solvedCoefficients_isTckTuple_forSplineModel(self):
+        # Contract: after Solve(), a spline model's solvedCoefficients is the
+        # scipy tck representation (a tuple), NOT a coefficient array.
+        # 2D: UnivariateSpline._eval_args == (knots, coefficients, degree).
+        model = pyeq3.Models_2D.Spline.Spline(inSmoothingFactor=1.0, inXOrder=3)
+        pyeq3.dataConvertorService().ConvertAndSortColumnarASCII(
+            DataForUnitTests.asciiDataInColumns_2D, model, False
+        )
+        model.Solve()
+        self.assertTrue(model.splineFlag)
+        self.assertIsInstance(model.solvedCoefficients, tuple)
+        self.assertEqual(len(model.solvedCoefficients), 3)
+
     def test_SolveUsingSpline_3D(self):
         xKnotPointsShouldBe = numpy.array([0.607, 0.607, 0.607, 3.017, 3.017, 3.017])
         yKnotPointsShouldBe = numpy.array([1.984, 1.984, 1.984, 3.153, 3.153, 3.153])


### PR DESCRIPTION
Fixes #16.

## Summary and motivation

This update addresses two related issues from #16:

1. `SolveUsingDE` would crash if `estimatedCoefficients` was an empty numpy array. The code checked `if inModel.estimatedCoefficients != []`. But `numpy.array([]) != []` returns an empty boolean array, which led to the error "The truth value of an empty array is ambiguous." I updated the check to use `len(...) > 0`, which is the same approach already used in `SolveUsingSelectedAlgorithm` and in `SolveUsingODR`.
2. Previously, the type and shape of `solvedCoefficients` after calling `Solve()` was not documented. I added a docstring to `IModel` that describes the expected output: a 1-D numpy array for analytic equations and a scipy tck tuple for spline models. I also noted that 3D degrees are stored in `(xOrder, yOrder)` and not in the tuple. The docstring explains how to distinguish between these cases using `splineFlag` and how to rebuild with `BuildSplineFromSolvedCoefficients()`.

Testing: I added a regression test to ensure that an empty numpy array on the DE path no longer causes an error. I also added two tests to check the shapes of the analytic-ndarray and spline-tuple outputs. All 124 tests in the full unittest suite now pass.

## Follow-up note

The same `!= []` comparison appears in about 50 other places, including `upperCoefficientBounds`, `lowerCoefficientBounds`, and `fixedCoefficients` across `IModel.py` and the `ExtendedVersionHandlers`. These have the same underlying numpy fragility, but fixing them is outside the scope of this update. I will open a separate issue to address those cases.

## Checklist

- [x] I have read CONTRIBUTING.md.
- [x] Tested locally (new unittest cases in `Test_SolverService.py`).
- [ ] Example: not applicable, as there is no new equation or feature surface.
- [ ] Changelog: the `docs/changes` directory does not exist in the repository.
