### PR TITLE
Sandbox User-Defined-Function eval against arbitrary code execution

### DIFF
--- a/pyeq3/IModel.py
+++ b/pyeq3/IModel.py
@@ -1045,6 +1045,15 @@ class IModel(object):
                 "function text"
             )
 
+        # reject anything outside safe arithmetic over X/Y, the coefficients,
+        # and the numpy tokens, before the string is mangled by
+        # ConvertStringIntsToStringFloats and later compiled and eval'd.
+        # stringToConvert is still the clean ProcessAndValidateFunctionString
+        # output here (brackets already []->(), digit-bearing tokens intact).
+        pyeq3.UdfSafety.ValidateUDFExpression(
+            stringToConvert, pyeq3.UdfSafety.CollectAllowedNames(self, dim)
+        )
+
         # now compile code object using safe tokens with integer conversion
         self.safe_dict = locals()
 

--- a/pyeq3/Models_2D/UserDefinedFunction.py
+++ b/pyeq3/Models_2D/UserDefinedFunction.py
@@ -103,7 +103,11 @@ class UserDefinedFunction(pyeq3.Model_2D_BaseClass.Model_2D_BaseClass):
         # eval uses previously compiled code for improved performance
         # based on http://lybniz2.sourceforge.net/safeeval._HTML
         try:
-            temp = eval(self.userFunctionCodeObject, globals(), self.safe_dict)
+            temp = eval(
+                self.userFunctionCodeObject,
+                {"__builtins__": None, "numpy": numpy},
+                self.safe_dict,
+            )
             return self.extendedVersionHandler.GetAdditionalModelPredictions(
                 temp, inCoeffs, inDataCacheDictionary, self
             )

--- a/pyeq3/UdfSafety.py
+++ b/pyeq3/UdfSafety.py
@@ -1,0 +1,108 @@
+#    pyeq3 is a collection of equations expressed as Python classes
+#
+#    Copyright (C) 2013 James R. Phillips
+#    2548 Vera Cruz Drive
+#    Birmingham, AL 35235 USA
+#
+#    https://github.com/equations-project/pyeq3
+#
+#    License: BSD-style (see LICENSE.txt in main source directory)
+
+"""AST allow-list sandbox for User-Defined-Function expression text.
+
+The UDF fit path eval()s user-submitted expressions. pyeq3's cosmetic gate
+(ProcessAndValidateFunctionString) does not reject dangerous names, so without
+this check an untrusted 2D UDF can reach remote code execution in the fitting
+process (for example __import__('os').system('id')*X). This module re-parses
+the expression and walks it against a strict allow-list, rejecting everything
+outside pure arithmetic over X/Y, coefficient names, and the numpy tokens
+pyeq3 injects into safe_dict.
+
+Rejecting every ast.Attribute and ast.Subscript node is the security core: a
+builtins-free eval namespace is still escapable through attribute traversal
+(().__class__.__bases__[0].__subclasses__()); removing "." and "[]" at the
+grammar level closes that whole family. Names starting with an underscore are
+rejected as belt-and-suspenders against dunders.
+"""
+
+import ast
+
+
+class UnsafeUDFError(Exception):
+    """A UDF expression contained a construct outside safe arithmetic."""
+
+
+# Expression-level nodes that pure arithmetic over named values may use.
+_allowedNodes = (
+    ast.Expression,
+    ast.BinOp,
+    ast.UnaryOp,
+    ast.Call,
+    ast.Name,
+    ast.Constant,
+    ast.Load,
+    # binary operators
+    ast.Add,
+    ast.Sub,
+    ast.Mult,
+    ast.Div,
+    ast.Mod,
+    ast.Pow,
+    ast.FloorDiv,
+    # unary operators
+    ast.UAdd,
+    ast.USub,
+)
+
+
+def ValidateUDFExpression(inExpressionText, inAllowedNames):
+    """Raise UnsafeUDFError unless inExpressionText is safe arithmetic over
+    inAllowedNames (a set of permitted bare identifiers: X/Y, coefficient
+    designators, and the numpy tokens pyeq3 injects into safe_dict)."""
+    try:
+        tree = ast.parse(inExpressionText, mode="eval")
+    except SyntaxError as exc:
+        raise UnsafeUDFError(f"could not parse expression ({exc})") from exc
+
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Attribute):
+            raise UnsafeUDFError("attribute access is not allowed")
+        if isinstance(node, ast.Subscript):
+            raise UnsafeUDFError("subscripting is not allowed")
+        if not isinstance(node, _allowedNodes):
+            raise UnsafeUDFError(f"{type(node).__name__} is not allowed")
+
+        if isinstance(node, ast.Constant):
+            if not isinstance(node.value, (int, float)) or isinstance(node.value, bool):
+                raise UnsafeUDFError("only real numeric constants are allowed")
+
+        if isinstance(node, ast.Name):
+            if node.id.startswith("_"):
+                raise UnsafeUDFError(f"name {node.id!r} is not allowed")
+            if node.id not in inAllowedNames:
+                raise UnsafeUDFError(f"unknown name {node.id!r}")
+
+        if isinstance(node, ast.Call):
+            if not isinstance(node.func, ast.Name):
+                raise UnsafeUDFError("only calls to named functions are allowed")
+            if node.keywords:
+                raise UnsafeUDFError("keyword arguments are not allowed")
+            if any(isinstance(arg, ast.Starred) for arg in node.args):
+                raise UnsafeUDFError("starred arguments are not allowed")
+
+
+def CollectAllowedNames(inEquation, dim):
+    """Build the permitted-name set for a UDF equation: X (plus Y for 3D), the
+    parsed coefficient designators, and every numpy token pyeq3 lists in
+    functionDictionary / constantsDictionary. Sourced from the same
+    dictionaries pyeq3 injects into safe_dict, so the allow-list cannot drift
+    from what eval actually has access to."""
+    names = {"X"}
+    if dim == 3:
+        names.add("Y")
+    names.update(inEquation._coefficientDesignators)
+    for tokens in inEquation.functionDictionary.values():
+        names.update(tokens)
+    for tokens in inEquation.constantsDictionary.values():
+        names.update(tokens)
+    return names

--- a/pyeq3/__init__.py
+++ b/pyeq3/__init__.py
@@ -149,6 +149,7 @@ Acknowledgement and Support
 """
 
 from . import IModel
+from . import UdfSafety
 from . import Models_3D
 from . import Models_2D
 from . import ExtendedVersionHandlers

--- a/unittests/Test_UserDefinedFunctionSafety.py
+++ b/unittests/Test_UserDefinedFunctionSafety.py
@@ -174,6 +174,40 @@ class TestUserDefinedFunctionSafety(unittest.TestCase):
         model.ParseAndCompileUserFunctionString("a*X + b*Y", 3)
         self.assertIsNotNone(model.userFunctionCodeObject)
 
+    def test_2D_eval_namespace_has_no_builtins(self):
+        # Defense-in-depth: even if a malicious code object bypassed the gate,
+        # the 2D eval namespace must not expose builtins. abs(X) is compiled
+        # directly here (the gate rejects "abs" cosmetically, so this bypasses
+        # it). abs is a Python builtin and is NOT a numpy token in safe_dict,
+        # so it resolves only if builtins are live. With the hardened namespace
+        # it raises NameError, which CalculateModelPredictions sanitises to
+        # 1e300; with live globals() it would return finite values.
+        model = pyeq3.Models_2D.UserDefinedFunction.UserDefinedFunction(
+            "SSQABS", "Default"
+        )
+        model.ParseAndCompileUserFunctionString("a + b*X", 2)
+        model.userFunctionCodeObject = compile("abs(X)", "<string>", "eval")
+        result = model.CalculateModelPredictions(
+            [1.0, 1.0], {"X": numpy.array([1.0, -2.0, 3.0])}
+        )
+        self.assertTrue(numpy.allclose(result, numpy.ones(3) * 1.0e300))
+
+    def test_benign_2D_still_solves(self):
+        # Positive control: the gate and hardened namespace do not break a
+        # legitimate fit. Expected coefficients match the existing
+        # Test_ModelSolveMethods.test_UserDefinedFunctionSolve_SSQABS_2D.
+        resultShouldBe = numpy.array([-7.88180304, 1.51245438])
+        model = pyeq3.Models_2D.UserDefinedFunction.UserDefinedFunction(
+            "SSQABS", "Default", "m*X + b"
+        )
+        pyeq3.dataConvertorService().ConvertAndSortColumnarASCII(
+            DataForUnitTests.asciiDataInColumns_2D_small, model, False
+        )
+        result = model.Solve()
+        self.assertTrue(
+            numpy.allclose(result, resultShouldBe, rtol=1.0e-06, atol=1.0e-300)
+        )
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/unittests/Test_UserDefinedFunctionSafety.py
+++ b/unittests/Test_UserDefinedFunctionSafety.py
@@ -1,0 +1,110 @@
+from . import DataForUnitTests
+import pyeq3
+import sys
+import os
+import unittest
+
+# the pyeq3 directory is located up one level from here
+if os.path.join(sys.path[0][: sys.path[0].rfind(os.sep)], "..") not in sys.path:
+    sys.path.append(os.path.join(sys.path[0][: sys.path[0].rfind(os.sep)], ".."))
+
+import numpy
+
+numpy.seterr(all="ignore")
+
+
+# X, Y, a few coefficients, and the numpy tokens a real UDF may use.
+ALLOWED = {
+    "X",
+    "Y",
+    "a",
+    "b",
+    "c",
+    "exp",
+    "sin",
+    "sqrt",
+    "fabs",
+    "arctan2",
+    "pi",
+    "e",
+}
+
+# Each must be REJECTED by the validator directly.
+MALICIOUS = [
+    "__import__('os').system('id')*X",  # builtins via dunder name
+    "().__class__.__bases__[0].__subclasses__()",  # attribute-traversal escape
+    "().__class__.__bases__[0]",  # subscript escape
+    "X.__class__",  # attribute access
+    "(1).__class__",  # attribute on a literal
+    "eval('1')+X",  # eval call
+    "exec('x')+X",  # exec call
+    "open('f') and X",  # file access + BoolOp
+    "globals() and X",  # builtins call
+    "'os' and X",  # string constant payload
+    "exp(x=1)+X",  # keyword-arg call
+    "foo*X",  # unknown bare name
+    "[X for a in X]",  # comprehension
+    "(lambda: X)()",  # lambda
+    "(a := X)",  # walrus / NamedExpr
+    "f'{X}'",  # f-string (JoinedStr)
+    "t'{X}'",  # t-string (py3.14); SyntaxError on older -> still rejected
+    "sin(X for a in X)",  # generator expression
+    "X if a else b",  # ternary IfExp
+    "a < X < b",  # chained compare
+    "exp(**a)",  # dict-unpack into call
+    "sin(open('x'))",  # dangerous inner call
+    "sin(X).real",  # attribute on a call result
+    "a*X + 1j",  # complex literal (only real numerics allowed)
+]
+
+# Each must be ACCEPTED by the validator directly.
+BENIGN = [
+    "a + b*X",
+    "a*exp(-b*X)+c",
+    "sin(X)+sqrt(fabs(X))",
+    "a*X**2 + b*X + c",
+    "a*X + b*Y",
+    "a*X + pi",
+    "arctan2(X, a)",
+]
+
+
+class TestUserDefinedFunctionSafety(unittest.TestCase):
+    def test_malicious_rejected_directly(self):
+        for expr in MALICIOUS:
+            with self.subTest(expr=expr):
+                with self.assertRaises(pyeq3.UdfSafety.UnsafeUDFError):
+                    pyeq3.UdfSafety.ValidateUDFExpression(expr, ALLOWED)
+
+    def test_benign_accepted_directly(self):
+        for expr in BENIGN:
+            with self.subTest(expr=expr):
+                # must not raise
+                pyeq3.UdfSafety.ValidateUDFExpression(expr, ALLOWED)
+
+    def test_syntax_error_is_unsafe_not_crash(self):
+        with self.assertRaises(pyeq3.UdfSafety.UnsafeUDFError):
+            pyeq3.UdfSafety.ValidateUDFExpression("a + *X", ALLOWED)
+
+    def test_collect_allowed_names_2D_excludes_Y(self):
+        model = pyeq3.Models_2D.UserDefinedFunction.UserDefinedFunction(
+            "SSQABS", "Default"
+        )
+        model.ParseAndCompileUserFunctionString("a + b*X", 2)
+        names = pyeq3.UdfSafety.CollectAllowedNames(model, 2)
+        self.assertIn("X", names)
+        self.assertNotIn("Y", names)
+        self.assertTrue({"a", "b"} <= names)
+        self.assertTrue({"exp", "sin", "sqrt", "pi", "e"} <= names)
+
+    def test_collect_allowed_names_3D_includes_Y(self):
+        model = pyeq3.Models_3D.UserDefinedFunction.UserDefinedFunction(
+            "SSQABS", "Default"
+        )
+        model.ParseAndCompileUserFunctionString("a*X + b*Y", 3)
+        names = pyeq3.UdfSafety.CollectAllowedNames(model, 3)
+        self.assertTrue({"X", "Y", "a", "b"} <= names)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/unittests/Test_UserDefinedFunctionSafety.py
+++ b/unittests/Test_UserDefinedFunctionSafety.py
@@ -68,6 +68,41 @@ BENIGN = [
     "arctan2(X, a)",
 ]
 
+# Validator-reaching malicious payloads: each contains X (and Y for 3D) and
+# avoids the substrings ProcessAndValidateFunctionString rejects cosmetically
+# (=, ^, ln, abs, EXP, LOG), so the AST validator (not a cosmetic check) is
+# what rejects them end-to-end through ParseAndCompileUserFunctionString.
+GATE_MALICIOUS_2D = [
+    "__import__('os').system('id')*X",
+    "X.__class__",
+    "eval('1')+X",
+    "globals() and X",
+    "'os' and X",
+    "sin(X).real",
+    "a*X + 1j",
+]
+
+GATE_MALICIOUS_3D = [
+    "__import__('os').system('id')*X + Y",
+    "X.__class__ + Y",
+    "sin(X).real + Y",
+]
+
+# Benign payloads that compile cleanly through the full path. Digit-bearing
+# function tokens (log10, arctan2, ...) are excluded: ConvertStringIntsToString-
+# Floats mangles them (log10 -> log10.0), a separate pre-existing bug.
+# Note: fabs() is intentionally absent here. pyeq3's cosmetic gate rejects any
+# string containing the substring "abs" (a pre-existing over-broad check that
+# also catches fabs), so fabs cannot pass the full path. The direct BENIGN list
+# above still covers fabs against the validator itself.
+GATE_BENIGN_2D = [
+    "a + b*X",
+    "a*exp(-b*X)+c",
+    "a*sin(X) + b*sqrt(X)",
+    "a*X**2 + b*X + c",
+    "a*X + pi",
+]
+
 
 class TestUserDefinedFunctionSafety(unittest.TestCase):
     def test_malicious_rejected_directly(self):
@@ -104,6 +139,40 @@ class TestUserDefinedFunctionSafety(unittest.TestCase):
         model.ParseAndCompileUserFunctionString("a*X + b*Y", 3)
         names = pyeq3.UdfSafety.CollectAllowedNames(model, 3)
         self.assertTrue({"X", "Y", "a", "b"} <= names)
+
+    def test_gate_rejects_malicious_2D(self):
+        for expr in GATE_MALICIOUS_2D:
+            with self.subTest(expr=expr):
+                model = pyeq3.Models_2D.UserDefinedFunction.UserDefinedFunction(
+                    "SSQABS", "Default"
+                )
+                with self.assertRaises(pyeq3.UdfSafety.UnsafeUDFError):
+                    model.ParseAndCompileUserFunctionString(expr, 2)
+
+    def test_gate_rejects_malicious_3D(self):
+        for expr in GATE_MALICIOUS_3D:
+            with self.subTest(expr=expr):
+                model = pyeq3.Models_3D.UserDefinedFunction.UserDefinedFunction(
+                    "SSQABS", "Default"
+                )
+                with self.assertRaises(pyeq3.UdfSafety.UnsafeUDFError):
+                    model.ParseAndCompileUserFunctionString(expr, 3)
+
+    def test_gate_accepts_benign_2D(self):
+        for expr in GATE_BENIGN_2D:
+            with self.subTest(expr=expr):
+                model = pyeq3.Models_2D.UserDefinedFunction.UserDefinedFunction(
+                    "SSQABS", "Default"
+                )
+                model.ParseAndCompileUserFunctionString(expr, 2)
+                self.assertIsNotNone(model.userFunctionCodeObject)
+
+    def test_gate_accepts_benign_3D(self):
+        model = pyeq3.Models_3D.UserDefinedFunction.UserDefinedFunction(
+            "SSQABS", "Default"
+        )
+        model.ParseAndCompileUserFunctionString("a*X + b*Y", 3)
+        self.assertIsNotNone(model.userFunctionCodeObject)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Fixes #36

## Summary

pyeq3 fits user-defined function equations by running eval() on user-supplied expressions. In the 2D model, these expressions used built-in functions from globals(), so an untrusted 2D UDF could run any code during fitting (for example, `__import__('os').system('id')*X`). The earlier protection only checked at a basic level and did not block risky names.

This update adds a check using the AST structure at pyeq3's main compile step (`IModel.ParseAndCompileUserFunctionString`, used by both 2D and 3D models). It also removes builtins from the 2D eval environment to match the 3D model.

## Changes

- Added `pyeq3/UdfSafety.py`, which uses Python's `ast` module to check user functions. It blocks all attribute access and indexing, stopping hacks like `().__class__.__bases__[0].__subclasses__()`. It also blocks anything that is not arithmetic, any constant that is not a real int or float, names starting with underscores or unknown names, and keyword or starred calls. The allowed names come from `X`/`Y`, the coefficient names, and the same `functionDictionary` and `constantsDictionary` that pyeq3 uses in `safe_dict`, so everything stays consistent. `IModel.ParseAndCompileUserFunctionString` now checks the expression after setting coefficient labels and before compiling. `Models_2D/UserDefinedFunction.py` now runs with `{"__builtins__": None, "numpy": numpy}` to match the 3D model.
- Added `unittests/Test_UserDefinedFunctionSafety.py`, which tests a group of harmful inputs (rejected in both 2D and 3D), a group of safe inputs (which still work), an extra namespace check for safety, and a real fitting test as a positive control.

## Why assert at the gate

`CalculateModelPredictions` turns any eval error into `1.0e300`, so a harmful UDF does not look like a fitting failure. The tests make sure that `ParseAndCompileUserFunctionString` (and the validator itself) raises an error directly, not through the fitting result.

## Testing

Running `python -m unittest discover -s unittests -t . -p "Test_*.py"` passes all 135 tests. The existing UDF solve tests still work as before.

## Out of scope (pre-existing, suitable as separate issues)

- `ConvertStringIntsToStringFloats` appends `.0` to digit-bearing identifiers (`log10` -> `log10.0`), so `log10`/`log2`/`arctan2`/`deg2rad`/`rad2deg` fail to compile in real fits.
- The cosmetic `"abs"` substring check also rejects `fabs`.
