### PR TITLE
allow fabs in user defined functions

### DIFF
--- a/pyeq3/IModel.py
+++ b/pyeq3/IModel.py
@@ -997,11 +997,15 @@ class IModel(object):
             )
 
         if "abs" in stringToConvert:
-            raise Exception(
-                "The parser uses fabs() for the absolute "
-                "value, not abs(). Please use fabs() in "
-                "your text."
-            )
+            # check if the previous character before "abs" is "f",
+            # if not, raise an exception
+            index = stringToConvert.find("abs")
+            if index == 0 or stringToConvert[index - 1] != "f":
+                raise Exception(
+                    "The parser uses fabs() for the absolute "
+                    "value, not abs(). Please use fabs() in "
+                    "your text."
+                )
 
         if "EXP" in stringToConvert:
             raise Exception(

--- a/unittests/Test_UserDefinedFunctionSafety.py
+++ b/unittests/Test_UserDefinedFunctionSafety.py
@@ -208,6 +208,32 @@ class TestUserDefinedFunctionSafety(unittest.TestCase):
             numpy.allclose(result, resultShouldBe, rtol=1.0e-06, atol=1.0e-300)
         )
 
+    def test_fabs_not_abs(self):
+        # Check that the cosmetic gate rejects "abs" but not "fabs", and that
+        # fabs() works in a fit. This is a regression test for the pre-existing
+        # over-broad "abs" check, which also caught "fabs" and thus prevented
+        # any user-defined function from using the absolute value.
+
+        # This test should produce an exception:
+        with self.assertRaises(Exception):
+            model = pyeq3.Models_2D.UserDefinedFunction.UserDefinedFunction(
+                "SSQABS", "Default", "abs(a*X)"
+            )
+
+        # This test should succeed:
+        model = pyeq3.Models_2D.UserDefinedFunction.UserDefinedFunction(
+            "SSQABS", "Default", "fabs(a*X)"
+        )
+        pyeq3.dataConvertorService().ConvertAndSortColumnarASCII(
+            DataForUnitTests.asciiDataInColumns_2D_small, model, False
+        )
+        result = model.Solve()
+        resultShouldBe = numpy.array([0.50368388])
+
+        self.assertTrue(
+            numpy.allclose(result, resultShouldBe, rtol=1.0e-06, atol=1.0e-300)
+        )
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
This pull request addresses a bug in the handling of absolute value functions within user-defined model strings. Previously, the parser incorrectly rejected valid uses of `fabs()` due to an over-broad check for the substring `abs`. The changes refine this check and add a regression test to ensure correct behavior.
