### PR TITLE
allow numeric functions

### DIFF
--- a/examples/Simple/CompareMultipleFittingAlgorithms_2D.py
+++ b/examples/Simple/CompareMultipleFittingAlgorithms_2D.py
@@ -63,9 +63,12 @@ for fittingAlgorithmName in fittingAlgorithmNames[1:]:
     deEstimatedCoefficients = equation.deEstimatedCoefficients
     value = equation.CalculateAllDataFittingTarget(equation.solvedCoefficients)
 
-    if value < LM_value:
+    if value < LM_value * (1.0 - 10.0 ** (-precision)):
         print(
             f"Algorithm {fittingAlgorithmName} fitted better than Levenberg-Marquardt!"
+        )
+        print(
+            f"{fittingTargetText} = {value:.2E} for the fitting algorithm {fittingAlgorithmName}"
         )
     else:
         print(

--- a/pyeq3/IModel.py
+++ b/pyeq3/IModel.py
@@ -15,6 +15,7 @@ import scipy.interpolate
 import scipy.stats
 import odrpack
 from itertools import groupby
+from pyeq3 import UdfSafety
 
 numpy.seterr(all="ignore")
 
@@ -918,8 +919,21 @@ class IModel(object):
         return str.isdigit(character) or character == "."
 
     def ConvertStringIntsToStringFloats(self, string):
+        for (
+            function,
+            numberFreeFunction,
+        ) in UdfSafety.numberContainingFunctionsToWords.items():
+            string = string.replace(function, numberFreeFunction)
+
         res = ["".join(g) for _, g in groupby(string, self.IsDigitOrPoint)]
-        return "".join([r + ".0" if r.isnumeric() else r for r in res])
+        newstring = "".join([r + ".0" if r.isnumeric() else r for r in res])
+
+        for (
+            numberFreeFunction,
+            function,
+        ) in UdfSafety.wordsToNumberContainingFunctions.items():
+            newstring = newstring.replace(numberFreeFunction, function)
+        return newstring
 
     def GetSortedCoefficientsFromString(self, string, dim):
         numpySafeTokenList = []

--- a/pyeq3/Models_2D/UserDefinedFunction.py
+++ b/pyeq3/Models_2D/UserDefinedFunction.py
@@ -16,6 +16,7 @@ if os.path.join(sys.path[0][: sys.path[0].rfind(os.sep)], "..") not in sys.path:
 
 import pyeq3
 import pyeq3.Model_2D_BaseClass
+from pyeq3 import UdfSafety
 
 # implicitly required by compiling the userFunctionCodeObject
 # in the method EvaluateCachedData() below
@@ -27,34 +28,9 @@ numpy.seterr(all="ignore")
 class UserDefinedFunction(pyeq3.Model_2D_BaseClass.Model_2D_BaseClass):
     userDefinedFunctionFlag = True
 
-    # based on http://lybniz2.sourceforge.net/safeeval.html
-    functionDictionary = {
-        "Exponents And Logarithms": ["exp", "log", "log10", "log2"],
-        "Trigonometric Functions": [
-            "sin",
-            "cos",
-            "tan",
-            "arcsin",
-            "arccos",
-            "arctan",
-            "hypot",
-            "arctan2",
-            "deg2rad",
-            "rad2deg",
-        ],
-        "Hyperbolic Trig Functions": [
-            "arcsinh",
-            "arccosh",
-            "arctanh",
-            "sinh",
-            "cosh",
-            "tanh",
-        ],
-        "Other Special Functions": ["sinc"],
-        "Miscellaneous": ["sqrt", "square", "fabs", "sign"],
-    }
+    functionDictionary = UdfSafety.functionDictionary
+    constantsDictionary = UdfSafety.constantsDictionary
 
-    constantsDictionary = {"Constants": ["pi", "e"]}
     _baseName = "User Defined Function"
 
     webReferenceURL = ""

--- a/pyeq3/Models_3D/UserDefinedFunction.py
+++ b/pyeq3/Models_3D/UserDefinedFunction.py
@@ -16,6 +16,7 @@ if os.path.join(sys.path[0][: sys.path[0].rfind(os.sep)], "..") not in sys.path:
 
 import pyeq3
 import pyeq3.Model_3D_BaseClass
+from pyeq3 import UdfSafety
 
 import numpy
 
@@ -25,34 +26,9 @@ numpy.seterr(all="ignore")
 class UserDefinedFunction(pyeq3.Model_3D_BaseClass.Model_3D_BaseClass):
     userDefinedFunctionFlag = True
 
-    # based on http://lybniz2.sourceforge.net/safeeval.html
-    functionDictionary = {
-        "Exponents And Logarithms": ["exp", "log", "log10", "log2"],
-        "Trigonometric Functions": [
-            "sin",
-            "cos",
-            "tan",
-            "arcsin",
-            "arccos",
-            "arctan",
-            "hypot",
-            "arctan2",
-            "deg2rad",
-            "rad2deg",
-        ],
-        "Hyperbolic Trig Functions": [
-            "arcsinh",
-            "arccosh",
-            "arctanh",
-            "sinh",
-            "cosh",
-            "tanh",
-        ],
-        "Other Special Functions": ["sinc"],
-        "Miscellaneous": ["sqrt", "square", "fabs", "sign"],
-    }
+    functionDictionary = UdfSafety.functionDictionary
+    constantsDictionary = UdfSafety.constantsDictionary
 
-    constantsDictionary = {"Constants": ["pi", "e"]}
     _baseName = "User Defined Function"
 
     webReferenceURL = ""

--- a/pyeq3/UdfSafety.py
+++ b/pyeq3/UdfSafety.py
@@ -32,6 +32,65 @@ class UnsafeUDFError(Exception):
     """A UDF expression contained a construct outside safe arithmetic."""
 
 
+# based on http://lybniz2.sourceforge.net/safeeval.html
+functionDictionary = {
+    "Exponents And Logarithms": ["exp", "log", "log10", "log2"],
+    "Trigonometric Functions": [
+        "sin",
+        "cos",
+        "tan",
+        "arcsin",
+        "arccos",
+        "arctan",
+        "hypot",
+        "arctan2",
+        "deg2rad",
+        "rad2deg",
+    ],
+    "Hyperbolic Trig Functions": [
+        "arcsinh",
+        "arccosh",
+        "arctanh",
+        "sinh",
+        "cosh",
+        "tanh",
+    ],
+    "Other Special Functions": ["sinc"],
+    "Miscellaneous": ["sqrt", "square", "fabs", "sign"],
+}
+constantsDictionary = {"Constants": ["pi", "e"]}
+
+# build a set of all the functions that contain numbers
+numberInLetters = {
+    "0": "Zero",
+    "1": "One",
+    "2": "Two",
+    "3": "Three",
+    "4": "Four",
+    "5": "Five",
+    "6": "Six",
+    "7": "Seven",
+    "8": "Eight",
+    "9": "Nine",
+}
+
+numberContainingFunctions = set()
+numberContainingFunctionsToWords = {}
+for functionList in functionDictionary.values():
+    for function in functionList:
+        if any(char.isdigit() for char in function):
+            numberContainingFunctions.add(function)
+
+            numberFreeFunction = function
+            for digit, word in numberInLetters.items():
+                numberFreeFunction = numberFreeFunction.replace(digit, word)
+
+            numberContainingFunctionsToWords[function] = numberFreeFunction
+
+wordsToNumberContainingFunctions = {
+    v: k for k, v in numberContainingFunctionsToWords.items()
+}
+
 # Expression-level nodes that pure arithmetic over named values may use.
 _allowedNodes = (
     ast.Expression,

--- a/unittests/Test_UserDefinedFunctionSafety.py
+++ b/unittests/Test_UserDefinedFunctionSafety.py
@@ -234,6 +234,30 @@ class TestUserDefinedFunctionSafety(unittest.TestCase):
             numpy.allclose(result, resultShouldBe, rtol=1.0e-06, atol=1.0e-300)
         )
 
+    def test_digit_bearing_functions(self):
+        # Check that digit-bearing function tokens (log10, arctan2, etc.) are
+        # rejected by the gate due to the ConvertStringIntsToStringFloats bug,
+        # and that they are accepted if the bug is patched. This is a
+        # regression test for the pre-existing bug where ConvertStringIntsTo-
+        # StringFloats mangled digit-bearing function tokens (log10 -> log10.0),
+        # causing them to fail validation and thus be unavailable in UDFs.
+
+        i = 0
+        for expr in pyeq3.UdfSafety.numberContainingFunctions:
+            with self.subTest(expr=expr):
+                model = pyeq3.Models_2D.UserDefinedFunction.UserDefinedFunction(
+                    "SSQABS", "Default", f"{expr}(a*X)"
+                )
+                pyeq3.dataConvertorService().ConvertAndSortColumnarASCII(
+                    DataForUnitTests.asciiDataInColumns_2D_small, model, False
+                )
+
+                self.assertIsNotNone(model.userFunctionCodeObject)
+            i += 1
+
+        # There should be 5 functions that contain digits
+        self.assertEqual(i, 5)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
This pull request:
* Moved the `functionDictionary` and `constantsDictionary` definitions from `UserDefinedFunction` classes in `Models_2D`
* Added logic in `UdfSafety` to map functions with digits in their names (e.g., `log10`) to digit-free versions (e.g., `logTen`) and back, and updated `ConvertStringIntsToStringFloats` in `IModel.py` to use these mappings, preventing accidental corruption of digit-bearing function names during string conversion.
* Added a regression test to ensure that digit-bearing functions are correctly accepted and processed in user-defined functions, addressing a prior bug where such functions were mangled and rejected.