### PR TITLE
Replace `!= []` coefficient-attribute checks that break with numpy arrays

### DIFF
--- a/pyeq3/ExtendedVersionHandlers/ExtendedVersionHandler_ExponentialDecay.py
+++ b/pyeq3/ExtendedVersionHandlers/ExtendedVersionHandler_ExponentialDecay.py
@@ -89,9 +89,9 @@ class ExtendedVersionHandler_ExponentialDecay(
         if inModel.baseEquationHasGlobalMultiplierOrDivisor_UsedInExtendedVersions:
             return
         else:
-            if inModel.upperCoefficientBounds != []:
+            if len(inModel.upperCoefficientBounds) > 0:
                 inModel.upperCoefficientBounds.append(None)
-            if inModel.lowerCoefficientBounds != []:
+            if len(inModel.lowerCoefficientBounds) > 0:
                 inModel.lowerCoefficientBounds.append(None)
 
     def AssembleOutputSourceCodeCPP(self, inModel):

--- a/pyeq3/ExtendedVersionHandlers/ExtendedVersionHandler_ExponentialDecayAndOffset.py
+++ b/pyeq3/ExtendedVersionHandlers/ExtendedVersionHandler_ExponentialDecayAndOffset.py
@@ -88,15 +88,15 @@ class ExtendedVersionHandler_ExponentialDecayAndOffset(
 
     def AppendAdditionalCoefficientBounds(self, inModel):
         if inModel.baseEquationHasGlobalMultiplierOrDivisor_UsedInExtendedVersions:
-            if inModel.upperCoefficientBounds != []:
+            if len(inModel.upperCoefficientBounds) > 0:
                 inModel.upperCoefficientBounds.append(None)
-            if inModel.lowerCoefficientBounds != []:
+            if len(inModel.lowerCoefficientBounds) > 0:
                 inModel.lowerCoefficientBounds.append(None)
         else:
-            if inModel.upperCoefficientBounds != []:
+            if len(inModel.upperCoefficientBounds) > 0:
                 inModel.upperCoefficientBounds.append(None)
                 inModel.upperCoefficientBounds.append(None)
-            if inModel.lowerCoefficientBounds != []:
+            if len(inModel.lowerCoefficientBounds) > 0:
                 inModel.lowerCoefficientBounds.append(None)
                 inModel.lowerCoefficientBounds.append(None)
 

--- a/pyeq3/ExtendedVersionHandlers/ExtendedVersionHandler_ExponentialGrowth.py
+++ b/pyeq3/ExtendedVersionHandlers/ExtendedVersionHandler_ExponentialGrowth.py
@@ -89,9 +89,9 @@ class ExtendedVersionHandler_ExponentialGrowth(
         if inModel.baseEquationHasGlobalMultiplierOrDivisor_UsedInExtendedVersions:
             return
         else:
-            if inModel.upperCoefficientBounds != []:
+            if len(inModel.upperCoefficientBounds) > 0:
                 inModel.upperCoefficientBounds.append(None)
-            if inModel.lowerCoefficientBounds != []:
+            if len(inModel.lowerCoefficientBounds) > 0:
                 inModel.lowerCoefficientBounds.append(None)
 
     def AssembleOutputSourceCodeCPP(self, inModel):

--- a/pyeq3/ExtendedVersionHandlers/ExtendedVersionHandler_ExponentialGrowthAndOffset.py
+++ b/pyeq3/ExtendedVersionHandlers/ExtendedVersionHandler_ExponentialGrowthAndOffset.py
@@ -88,15 +88,15 @@ class ExtendedVersionHandler_ExponentialGrowthAndOffset(
 
     def AppendAdditionalCoefficientBounds(self, inModel):
         if inModel.baseEquationHasGlobalMultiplierOrDivisor_UsedInExtendedVersions:
-            if inModel.upperCoefficientBounds != []:
+            if len(inModel.upperCoefficientBounds) > 0:
                 inModel.upperCoefficientBounds.append(None)
-            if inModel.lowerCoefficientBounds != []:
+            if len(inModel.lowerCoefficientBounds) > 0:
                 inModel.lowerCoefficientBounds.append(None)
         else:
-            if inModel.upperCoefficientBounds != []:
+            if len(inModel.upperCoefficientBounds) > 0:
                 inModel.upperCoefficientBounds.append(None)
                 inModel.upperCoefficientBounds.append(None)
-            if inModel.lowerCoefficientBounds != []:
+            if len(inModel.lowerCoefficientBounds) > 0:
                 inModel.lowerCoefficientBounds.append(None)
                 inModel.lowerCoefficientBounds.append(None)
 

--- a/pyeq3/ExtendedVersionHandlers/ExtendedVersionHandler_InverseWithOffset.py
+++ b/pyeq3/ExtendedVersionHandlers/ExtendedVersionHandler_InverseWithOffset.py
@@ -52,9 +52,9 @@ class ExtendedVersionHandler_InverseWithOffset(
     # overridden from abstract parent class
 
     def AppendAdditionalCoefficientBounds(self, inModel):
-        if inModel.upperCoefficientBounds != []:
+        if len(inModel.upperCoefficientBounds) > 0:
             inModel.upperCoefficientBounds.append(None)
-        if inModel.lowerCoefficientBounds != []:
+        if len(inModel.lowerCoefficientBounds) > 0:
             inModel.lowerCoefficientBounds.append(None)
 
     def AssembleOutputSourceCodeCPP(self, inModel):

--- a/pyeq3/ExtendedVersionHandlers/ExtendedVersionHandler_LinearDecay.py
+++ b/pyeq3/ExtendedVersionHandlers/ExtendedVersionHandler_LinearDecay.py
@@ -84,9 +84,9 @@ class ExtendedVersionHandler_LinearDecay(
         if inModel.baseEquationHasGlobalMultiplierOrDivisor_UsedInExtendedVersions:
             return
         else:
-            if inModel.upperCoefficientBounds != []:
+            if len(inModel.upperCoefficientBounds) > 0:
                 inModel.upperCoefficientBounds.append(None)
-            if inModel.lowerCoefficientBounds != []:
+            if len(inModel.lowerCoefficientBounds) > 0:
                 inModel.lowerCoefficientBounds.append(None)
 
     def AssembleOutputSourceCodeCPP(self, inModel):

--- a/pyeq3/ExtendedVersionHandlers/ExtendedVersionHandler_LinearDecayAndOffset.py
+++ b/pyeq3/ExtendedVersionHandlers/ExtendedVersionHandler_LinearDecayAndOffset.py
@@ -83,15 +83,15 @@ class ExtendedVersionHandler_LinearDecayAndOffset(
     # overridden from abstract parent class
     def AppendAdditionalCoefficientBounds(self, inModel):
         if inModel.baseEquationHasGlobalMultiplierOrDivisor_UsedInExtendedVersions:
-            if inModel.upperCoefficientBounds != []:
+            if len(inModel.upperCoefficientBounds) > 0:
                 inModel.upperCoefficientBounds.append(None)
-            if inModel.lowerCoefficientBounds != []:
+            if len(inModel.lowerCoefficientBounds) > 0:
                 inModel.lowerCoefficientBounds.append(None)
         else:
-            if inModel.upperCoefficientBounds != []:
+            if len(inModel.upperCoefficientBounds) > 0:
                 inModel.upperCoefficientBounds.append(None)
                 inModel.upperCoefficientBounds.append(None)
-            if inModel.lowerCoefficientBounds != []:
+            if len(inModel.lowerCoefficientBounds) > 0:
                 inModel.lowerCoefficientBounds.append(None)
                 inModel.lowerCoefficientBounds.append(None)
 

--- a/pyeq3/ExtendedVersionHandlers/ExtendedVersionHandler_LinearGrowth.py
+++ b/pyeq3/ExtendedVersionHandlers/ExtendedVersionHandler_LinearGrowth.py
@@ -83,9 +83,9 @@ class ExtendedVersionHandler_LinearGrowth(
         if inModel.baseEquationHasGlobalMultiplierOrDivisor_UsedInExtendedVersions:
             return
         else:
-            if inModel.upperCoefficientBounds != []:
+            if len(inModel.upperCoefficientBounds) > 0:
                 inModel.upperCoefficientBounds.append(None)
-            if inModel.lowerCoefficientBounds != []:
+            if len(inModel.lowerCoefficientBounds) > 0:
                 inModel.lowerCoefficientBounds.append(None)
 
     def AssembleOutputSourceCodeCPP(self, inModel):

--- a/pyeq3/ExtendedVersionHandlers/ExtendedVersionHandler_LinearGrowthAndOffset.py
+++ b/pyeq3/ExtendedVersionHandlers/ExtendedVersionHandler_LinearGrowthAndOffset.py
@@ -84,15 +84,15 @@ class ExtendedVersionHandler_LinearGrowthAndOffset(
 
     def AppendAdditionalCoefficientBounds(self, inModel):
         if inModel.baseEquationHasGlobalMultiplierOrDivisor_UsedInExtendedVersions:
-            if inModel.upperCoefficientBounds != []:
+            if len(inModel.upperCoefficientBounds) > 0:
                 inModel.upperCoefficientBounds.append(None)
-            if inModel.lowerCoefficientBounds != []:
+            if len(inModel.lowerCoefficientBounds) > 0:
                 inModel.lowerCoefficientBounds.append(None)
         else:
-            if inModel.upperCoefficientBounds != []:
+            if len(inModel.upperCoefficientBounds) > 0:
                 inModel.upperCoefficientBounds.append(None)
                 inModel.upperCoefficientBounds.append(None)
-            if inModel.lowerCoefficientBounds != []:
+            if len(inModel.lowerCoefficientBounds) > 0:
                 inModel.lowerCoefficientBounds.append(None)
                 inModel.lowerCoefficientBounds.append(None)
 

--- a/pyeq3/ExtendedVersionHandlers/ExtendedVersionHandler_Offset.py
+++ b/pyeq3/ExtendedVersionHandlers/ExtendedVersionHandler_Offset.py
@@ -32,9 +32,9 @@ class ExtendedVersionHandler_Offset(IExtendedVersionHandler.IExtendedVersionHand
     # overridden from abstract parent class
 
     def AppendAdditionalCoefficientBounds(self, inModel):
-        if inModel.upperCoefficientBounds != []:
+        if len(inModel.upperCoefficientBounds) > 0:
             inModel.upperCoefficientBounds.append(None)
-        if inModel.lowerCoefficientBounds != []:
+        if len(inModel.lowerCoefficientBounds) > 0:
             inModel.lowerCoefficientBounds.append(None)
 
     def AssembleOutputSourceCodeCPP(self, inModel):

--- a/pyeq3/ExtendedVersionHandlers/ExtendedVersionHandler_PlusLine.py
+++ b/pyeq3/ExtendedVersionHandlers/ExtendedVersionHandler_PlusLine.py
@@ -49,10 +49,10 @@ class ExtendedVersionHandler_PlusLine(IExtendedVersionHandler.IExtendedVersionHa
     # overridden from abstract parent class
 
     def AppendAdditionalCoefficientBounds(self, inModel):
-        if inModel.upperCoefficientBounds != []:
+        if len(inModel.upperCoefficientBounds) > 0:
             inModel.upperCoefficientBounds.append(None)
             inModel.upperCoefficientBounds.append(None)
-        if inModel.lowerCoefficientBounds != []:
+        if len(inModel.lowerCoefficientBounds) > 0:
             inModel.lowerCoefficientBounds.append(None)
             inModel.lowerCoefficientBounds.append(None)
 

--- a/pyeq3/ExtendedVersionHandlers/ExtendedVersionHandler_PlusPlane.py
+++ b/pyeq3/ExtendedVersionHandlers/ExtendedVersionHandler_PlusPlane.py
@@ -53,11 +53,11 @@ class ExtendedVersionHandler_PlusPlane(IExtendedVersionHandler.IExtendedVersionH
     # overridden from abstract parent class
 
     def AppendAdditionalCoefficientBounds(self, inModel):
-        if inModel.upperCoefficientBounds != []:
+        if len(inModel.upperCoefficientBounds) > 0:
             inModel.upperCoefficientBounds.append(None)
             inModel.upperCoefficientBounds.append(None)
             inModel.upperCoefficientBounds.append(None)
-        if inModel.lowerCoefficientBounds != []:
+        if len(inModel.lowerCoefficientBounds) > 0:
             inModel.lowerCoefficientBounds.append(None)
             inModel.lowerCoefficientBounds.append(None)
             inModel.lowerCoefficientBounds.append(None)

--- a/pyeq3/ExtendedVersionHandlers/ExtendedVersionHandler_ReciprocalWithOffset.py
+++ b/pyeq3/ExtendedVersionHandlers/ExtendedVersionHandler_ReciprocalWithOffset.py
@@ -41,9 +41,9 @@ class ExtendedVersionHandler_ReciprocalWithOffset(
     # overridden from abstract parent class
 
     def AppendAdditionalCoefficientBounds(self, inModel):
-        if inModel.upperCoefficientBounds != []:
+        if len(inModel.upperCoefficientBounds) > 0:
             inModel.upperCoefficientBounds.append(None)
-        if inModel.lowerCoefficientBounds != []:
+        if len(inModel.lowerCoefficientBounds) > 0:
             inModel.lowerCoefficientBounds.append(None)
 
     def AssembleOutputSourceCodeCPP(self, inModel):

--- a/pyeq3/IModel.py
+++ b/pyeq3/IModel.py
@@ -469,20 +469,20 @@ class IModel(object):
         self.fixedCoefficients = fixedCoefficients
 
     def CalculateModelErrors(self, inCoeffs, inDictionary):
-        if self.upperCoefficientBounds != []:
+        if len(self.upperCoefficientBounds) > 0:
             for i in range(len(inCoeffs)):
                 # use None as a flag for coefficients that are not fixed
                 if self.upperCoefficientBounds[i] is not None:
                     if inCoeffs[i] > self.upperCoefficientBounds[i]:
                         inCoeffs[i] = self.upperCoefficientBounds[i]
-        if self.lowerCoefficientBounds != []:
+        if len(self.lowerCoefficientBounds) > 0:
             for i in range(len(inCoeffs)):
                 # use None as a flag for coefficients
                 # that are not fixed
                 if self.lowerCoefficientBounds[i] is not None:
                     if inCoeffs[i] < self.lowerCoefficientBounds[i]:
                         inCoeffs[i] = self.lowerCoefficientBounds[i]
-        if self.fixedCoefficients != []:
+        if len(self.fixedCoefficients) > 0:
             for i in range(len(inCoeffs)):
                 # use None as a flag for coefficients
                 # that are not fixed
@@ -506,14 +506,14 @@ class IModel(object):
         # save time by checking constraints and bounds first
         if not self.AreCoefficientsWithinBounds(inCoeffs):
             try:  # set any bounds
-                if self.upperCoefficientBounds != []:
+                if len(self.upperCoefficientBounds) > 0:
                     for i in range(len(inCoeffs)):
                         # use None as a flag for coefficients
                         # that are not fixed
                         if self.upperCoefficientBounds[i] is not None:
                             if inCoeffs[i] > self.upperCoefficientBounds[i]:
                                 inCoeffs[i] = self.upperCoefficientBounds[i]
-                if self.lowerCoefficientBounds != []:
+                if len(self.lowerCoefficientBounds) > 0:
                     for i in range(len(inCoeffs)):
                         # use None as a flag for coefficients
                         # that are not fixed
@@ -527,7 +527,7 @@ class IModel(object):
         # initial coefficients
         try:
             # set any fixed coefficients
-            if self.fixedCoefficients != []:
+            if len(self.fixedCoefficients) > 0:
                 for i in range(len(inCoeffs)):
                     # use None as a flag for coefficients that are not fixed
                     if self.fixedCoefficients[i] is not None:
@@ -551,14 +551,14 @@ class IModel(object):
         # save time by checking bounds first
         if not self.AreCoefficientsWithinBounds(inCoeffs):
             try:  # set to bounds
-                if self.upperCoefficientBounds != []:
+                if len(self.upperCoefficientBounds) > 0:
                     for i in range(len(inCoeffs)):
                         # use None as a flag for coefficients
                         # that are not fixed
                         if self.upperCoefficientBounds[i] is not None:
                             if inCoeffs[i] > self.upperCoefficientBounds[i]:
                                 inCoeffs[i] = self.upperCoefficientBounds[i]
-                if self.lowerCoefficientBounds != []:
+                if len(self.lowerCoefficientBounds) > 0:
                     for i in range(len(inCoeffs)):
                         # use None as a flag for coefficients
                         # that are not fixed
@@ -570,7 +570,7 @@ class IModel(object):
 
         try:
             # set any fixed coefficients
-            if self.fixedCoefficients != []:
+            if len(self.fixedCoefficients) > 0:
                 for i in range(len(inCoeffs)):
                     # use None as a flag for coefficients that are not fixed
                     if self.fixedCoefficients[i] is not None:
@@ -704,9 +704,9 @@ class IModel(object):
 
         # if any of these conditions exist, a linear solver cannot be used
         if (
-            self.fixedCoefficients != []
-            or self.upperCoefficientBounds != []
-            or self.lowerCoefficientBounds != []
+            len(self.fixedCoefficients) > 0
+            or len(self.upperCoefficientBounds) > 0
+            or len(self.lowerCoefficientBounds) > 0
             or len(self.dataCache.allDataCacheDictionary["Weights"])
         ):
             self._canLinearSolverBeUsedForSSQABS = False
@@ -732,13 +732,13 @@ class IModel(object):
             return solver.SolveUsingSimplex(self)
 
     def AreCoefficientsWithinBounds(self, inCoeffs):
-        if self.upperCoefficientBounds != []:
+        if len(self.upperCoefficientBounds) > 0:
             for index in range(len(inCoeffs)):
                 if (self.upperCoefficientBounds[index] is not None) and (
                     inCoeffs[index] > self.upperCoefficientBounds[index]
                 ):
                     return False
-        if self.lowerCoefficientBounds != []:
+        if len(self.lowerCoefficientBounds) > 0:
             for index in range(len(inCoeffs)):
                 if (self.lowerCoefficientBounds[index] is not None) and (
                     inCoeffs[index] < self.lowerCoefficientBounds[index]
@@ -763,19 +763,19 @@ class IModel(object):
     def WrapperForScipyCurveFit(self, data, *inCoeffs):
         # so coefficient assigment can be made
         inCoeffs = numpy.array(inCoeffs)
-        if self.upperCoefficientBounds != []:
+        if len(self.upperCoefficientBounds) > 0:
             for i in range(len(inCoeffs)):
                 # use None as a flag for coefficients that are not fixed
                 if self.upperCoefficientBounds[i] is not None:
                     if inCoeffs[i] > self.upperCoefficientBounds[i]:
                         inCoeffs[i] = self.upperCoefficientBounds[i]
-        if self.lowerCoefficientBounds != []:
+        if len(self.lowerCoefficientBounds) > 0:
             for i in range(len(inCoeffs)):
                 # use None as a flag for coefficients that are not fixed
                 if self.lowerCoefficientBounds[i] is not None:
                     if inCoeffs[i] < self.lowerCoefficientBounds[i]:
                         inCoeffs[i] = self.lowerCoefficientBounds[i]
-        if self.fixedCoefficients != []:
+        if len(self.fixedCoefficients) > 0:
             for i in range(len(inCoeffs)):
                 # use None as a flag for coefficients that are not fixed
                 if self.fixedCoefficients[i] is not None:
@@ -794,19 +794,19 @@ class IModel(object):
         if numpy.array_equal(
             data, self.dataCache.allDataCacheDictionary["IndependentData"]
         ):
-            if self.upperCoefficientBounds != []:
+            if len(self.upperCoefficientBounds) > 0:
                 for i in range(len(inCoeffs)):
                     # use None as a flag for coefficients that are not fixed
                     if self.upperCoefficientBounds[i] is not None:
                         if inCoeffs[i] > self.upperCoefficientBounds[i]:
                             inCoeffs[i] = self.upperCoefficientBounds[i]
-            if self.lowerCoefficientBounds != []:
+            if len(self.lowerCoefficientBounds) > 0:
                 for i in range(len(inCoeffs)):
                     # use None as a flag for coefficients that are not fixed
                     if self.lowerCoefficientBounds[i] is not None:
                         if inCoeffs[i] < self.lowerCoefficientBounds[i]:
                             inCoeffs[i] = self.lowerCoefficientBounds[i]
-            if self.fixedCoefficients != []:
+            if len(self.fixedCoefficients) > 0:
                 for i in range(len(inCoeffs)):
                     # use None as a flag for coefficients that are not fixed
                     if self.fixedCoefficients[i] is not None:
@@ -819,19 +819,19 @@ class IModel(object):
             self.dataCache.allDataCacheDictionary = {}
             self.dataCache.allDataCacheDictionary["IndependentData"] = data
             self.dataCache.FindOrCreateAllDataCache(self)
-            if self.upperCoefficientBounds != []:
+            if len(self.upperCoefficientBounds) > 0:
                 for i in range(len(inCoeffs)):
                     # use None as a flag for coefficients that are not fixed
                     if self.upperCoefficientBounds[i] is not None:
                         if inCoeffs[i] > self.upperCoefficientBounds[i]:
                             inCoeffs[i] = self.upperCoefficientBounds[i]
-            if self.lowerCoefficientBounds != []:
+            if len(self.lowerCoefficientBounds) > 0:
                 for i in range(len(inCoeffs)):
                     # use None as a flag for coefficients that are not fixed
                     if self.lowerCoefficientBounds[i] is not None:
                         if inCoeffs[i] < self.lowerCoefficientBounds[i]:
                             inCoeffs[i] = self.lowerCoefficientBounds[i]
-            if self.fixedCoefficients != []:
+            if len(self.fixedCoefficients) > 0:
                 for i in range(len(inCoeffs)):
                     # use None as a flag for coefficients that are not fixed
                     if self.fixedCoefficients[i] is not None:

--- a/unittests/Test_ExtendedVersionHandlers.py
+++ b/unittests/Test_ExtendedVersionHandlers.py
@@ -356,6 +356,21 @@ class TestExtendedVersionHandlers(unittest.TestCase):
         )
         self.assertTrue(fittingTarget <= 0.017)
 
+    def test_AppendAdditionalCoefficientBounds_emptyNumpyArrays_doesNotRaise(self):
+        # Regression for issue #34: the handlers check
+        # `if inModel.upperCoefficientBounds != []` before appending a None
+        # bound for their extra coefficient. With an EMPTY numpy array
+        # assigned, that comparison is an empty bool array and `if` on it
+        # raises "The truth value of an empty array is ambiguous". Empty
+        # bounds must be treated like the default empty lists: nothing to
+        # append to, nothing appended.
+        equation = pyeq3.Models_2D.Exponential.Exponential("SSQABS", "Offset")
+        equation.upperCoefficientBounds = numpy.array([])
+        equation.lowerCoefficientBounds = numpy.array([])
+        equation.extendedVersionHandler.AppendAdditionalCoefficientBounds(equation)
+        self.assertEqual(len(equation.upperCoefficientBounds), 0)
+        self.assertEqual(len(equation.lowerCoefficientBounds), 0)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/unittests/Test_ModelSolveMethods.py
+++ b/unittests/Test_ModelSolveMethods.py
@@ -185,6 +185,53 @@ class TestModelSolveMethods(unittest.TestCase):
         sourceCode = pyeq3.outputSourceCodeService().GetOutputSourceCodePYTHON(reloaded)
         self.assertTrue(len(sourceCode) > 0)
 
+    def test_Solve_emptyNumpyArrayCoefficientConstraints_doesNotRaise(self):
+        # Regression for issue #34: assigning EMPTY numpy arrays to the
+        # coefficient-constraint attributes used to crash Solve(). The checks
+        # `if self.fixedCoefficients != []` (and the bounds equivalents)
+        # evaluated `numpy.array([]) != []`, which is an empty bool array,
+        # and `if` on it raises "The truth value of an empty array is
+        # ambiguous". Empty constraints must behave exactly like the default
+        # empty lists, including keeping the linear solver path usable.
+        coefficientsShouldBe = numpy.array(
+            [-8.0191356407516956e00, 1.5264472941853220e00]
+        )
+        model = pyeq3.Models_2D.Polynomial.Linear("SSQABS")
+        model.upperCoefficientBounds = numpy.array([])
+        model.lowerCoefficientBounds = numpy.array([])
+        model.fixedCoefficients = numpy.array([])
+        pyeq3.dataConvertorService().ConvertAndSortColumnarASCII(
+            DataForUnitTests.asciiDataInColumns_2D, model, False
+        )
+        coefficients = model.Solve()
+        self.assertTrue(model.CanLinearSolverBeUsedForSSQABS())
+        self.assertTrue(
+            numpy.allclose(
+                coefficients, coefficientsShouldBe, rtol=1.0e-10, atol=1.0e-300
+            )
+        )
+
+    def test_Solve_numpyArrayCoefficientBounds_doesNotRaise(self):
+        # Regression for issue #34, non-empty case: on numpy 2.x,
+        # `numpy.array([20.0, 10.0]) != []` raises "operands could not be
+        # broadcast together" instead of returning a truth value, so
+        # assigning numpy arrays as coefficient bounds crashed Solve().
+        # These bounds do not bind, so the fit must match the unbounded
+        # non-linear result.
+        coefficientsShouldBe = numpy.array([-8.01913562, 1.52644729])
+        model = pyeq3.Models_2D.Polynomial.Linear("SSQABS")
+        model.upperCoefficientBounds = numpy.array([20.0, 10.0])
+        model.lowerCoefficientBounds = numpy.array([-20.0, -10.0])
+        pyeq3.dataConvertorService().ConvertAndSortColumnarASCII(
+            DataForUnitTests.asciiDataInColumns_2D, model, False
+        )
+        coefficients = model.Solve()
+        self.assertTrue(
+            numpy.allclose(
+                coefficients, coefficientsShouldBe, rtol=1.0e-03, atol=1.0e-300
+            )
+        )
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
This update fixes #34 and follows up on #16 and #33.

The code checked `fixedCoefficients`, `upperCoefficientBounds`, and `lowerCoefficientBounds` against an empty list using `!= []` in 57 places: 23 times in `pyeq3/IModel.py` and 34 times in `pyeq3/ExtendedVersionHandlers/`. If a numpy array is used for any of these attributes instead of a list, problems can occur:

* If the array is empty, using `if X != []` raises `ValueError: The truth value of an empty array is ambiguous`. This is the same error that issue #33 fixed for `estimatedCoefficients`.
* In numpy 2.x, if the array is not empty, the comparison causes `ValueError: operands could not be broadcast together`, making `Solve()` fail immediately during the linear solver check. In numpy 1.x, this only shows a warning, and the check still works.

Now, each check uses `len(X) > 0`, just like `SolveUsingSelectedAlgorithm`, `SolveUsingODR`, and `SolveUsingDE` do for `estimatedCoefficients`. This keeps the behavior for regular lists unchanged and only addresses the specific problem described.

Testing included three regression tests that failed before this change and now pass. Two tests in `unittests/Test_ModelSolveMethods.py` check `Solve()` with empty numpy constraint arrays (linear path) and with non-empty numpy bounds (DE and non-linear path). One test in `unittests/Test_ExtendedVersionHandlers.py` checks the `AppendAdditionalCoefficientBounds` handler. All 140 tests in the full suite pass on Python 3.14 with numpy 2.4.6.

### For new features/models or changes of existing features:

* [x] I have tested my changes locally to confirm they work as expected.

No example was added since this is a simple bug fix and does not introduce any new features for users. Also, the changelog folder mentioned in the template does not exist in this project.
